### PR TITLE
Decouple arm/gripper selection; allow EE mass/inertia" --body "Decouple arm XML selection from gripper choice and expose end-effector mass/inertia parameters for gravity compensation tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ i2rt.egg-info/
 
 # Ignore temporary scripts or generated files
 scripts/temp_*/
+i2rt/robot_models/yam/combined_arm_gripper.xml

--- a/i2rt/robots/get_robot.py
+++ b/i2rt/robots/get_robot.py
@@ -1,6 +1,10 @@
 import logging
-import time
+import time, os
 from functools import partial
+import xml.etree.ElementTree as ET
+from copy import deepcopy
+import tempfile
+from typing import Optional
 
 import numpy as np
 
@@ -12,8 +16,86 @@ from i2rt.motor_drivers.dm_driver import (
     ReceiveMode,
 )
 from i2rt.robots.motor_chain_robot import MotorChainRobot
-from i2rt.robots.utils import GripperType
+from i2rt.robots.utils import GripperType, ArmType
 
+def combine_arm_and_gripper_xml(arm_path, gripper_path, ee_mass=None, ee_inertia=None) -> str:
+    """Combine arm and gripper XML files into a single XML string.
+
+    Replaces the <body name="link_6"> subtree in the arm XML with the one from the
+    gripper XML (if present). If ee_mass or ee_inertia are provided, update the
+    inertial properties of the resulting link_6. Returns the combined XML as a string.
+    """
+    arm_tree = ET.parse(arm_path)
+    arm_root = arm_tree.getroot()
+
+    # attempt to load gripper and replace link_6 if available
+    if gripper_path:
+        try:
+            grip_tree = ET.parse(gripper_path)
+            grip_root = grip_tree.getroot()
+            grip_body = grip_root.find(".//body[@name='link_6']")
+        except Exception:
+            grip_body = None
+
+        # merge assets (avoid duplicates)
+        if grip_root is not None:
+            arm_asset = arm_root.find("asset")
+            grip_asset = grip_root.find("asset")
+            if grip_asset is not None:
+                if arm_asset is None:
+                    arm_asset = ET.Element("asset")
+                    worldbody = arm_root.find("worldbody")
+                    if worldbody is not None:
+                        arm_root.insert(list(arm_root).index(worldbody), arm_asset)
+                    else:
+                        arm_root.append(arm_asset)
+                existing = {(c.tag, c.get("name")) for c in arm_asset}
+                for child in grip_asset:
+                    key = (child.tag, child.get("name"))
+                    if key not in existing:
+                        arm_asset.append(deepcopy(child))
+                        existing.add(key)
+
+        # replace arm's link_6 with gripper's if found
+        if grip_body is not None:
+            replaced = False
+            for parent in arm_root.iter():
+                children = list(parent)
+                for idx, child in enumerate(children):
+                    if child.tag == "body" and child.get("name") == "link_6":
+                        parent.remove(child)
+                        parent.insert(idx, deepcopy(grip_body))
+                        replaced = True
+                        break
+                if replaced:
+                    break
+
+    # find resulting link_6 and apply end-effector overrides (mass/inertia)
+    res_body = arm_root.find(".//body[@name='link_6']")
+    if res_body is not None:
+        inertial = res_body.find("inertial")
+        if inertial is None:
+            inertial = ET.SubElement(res_body, "inertial")
+
+        if ee_mass is not None:
+            inertial.set("mass", str(float(ee_mass)))
+
+        if ee_inertia is not None:
+            arr = np.asarray(ee_inertia).ravel()
+            ipos = " ".join(str(float(x)) for x in arr[:3])
+            inertial.set("ipos", ipos)
+            quat = " ".join(str(float(x)) for x in arr[3:7])
+            inertial.set("quat", quat)
+            diagin = " ".join(str(float(x)) for x in arr[-3:])
+            inertial.set("diaginertia", diagin)
+
+    # return XML string (with declaration)
+    # xml_str = ET.tostring(arm_root, encoding="unicode")
+    # return xml_str
+    # write combined xml to file (out_path or temp file) and return filepath
+    out_path = os.path.split(arm_path)[0] + "/combined_arm_gripper.xml"
+    arm_tree.write(out_path, encoding="utf-8", xml_declaration=True)
+    return out_path
 
 def get_encoder_chain(can_interface: CanInterface) -> EncoderChain:
     passive_encoder_reader = PassiveEncoderReader(can_interface)
@@ -22,8 +104,11 @@ def get_encoder_chain(can_interface: CanInterface) -> EncoderChain:
 
 def get_yam_robot(
     channel: str = "can0",
+    arm_type: ArmType = ArmType.YAM,
     gripper_type: GripperType = GripperType.CRANK_4310,
     zero_gravity_mode:bool = True,
+    ee_mass: Optional[float] = None, # scalar
+    ee_inertia: Optional[np.ndarray] = None, # 10-dim array: ipos(3) + quat(4) + diaginertia(3) or full inertia(6)  
 ) -> MotorChainRobot:
     with_gripper = True
     with_teaching_handle = False
@@ -34,7 +119,10 @@ def get_yam_robot(
         with_gripper = False
         with_teaching_handle = False
 
-    model_path = gripper_type.get_xml_path()
+    gripper_path = gripper_type.get_xml_path()
+    arm_path = arm_type.get_xml_path()
+    model_path = combine_arm_and_gripper_xml(arm_path, gripper_path, ee_mass, ee_inertia)
+
     motor_list = [
         [0x01, "DM4340"],
         [0x02, "DM4340"],

--- a/i2rt/robots/utils.py
+++ b/i2rt/robots/utils.py
@@ -17,6 +17,33 @@ YAM_XML_LINEAR_4310_PATH = os.path.join(I2RT_ROOT, "robot_models/yam/yam_4310_li
 YAM_TEACHING_HANDLE_PATH = os.path.join(I2RT_ROOT, "robot_models/yam/yam_teaching_handle.xml")
 YAM_NO_GRIPPER_PATH = os.path.join(I2RT_ROOT, "robot_models/yam/yam_no_gripper.xml")
 
+ARM_YAM_XML_PATH = os.path.join(I2RT_ROOT, "robot_models/yam/yam.xml")
+ARM_ARX_XML_PATH = os.path.join(I2RT_ROOT, "robot_models/arx/arx.xml")
+
+class ArmType(enum.Enum):
+    YAM = "yam"
+    ARX = "arx"
+
+    @classmethod
+    def from_string_name(cls, name: str) -> "ArmType":
+        if name == "yam":
+            return cls.YAM
+        elif name == "arx":
+            return cls.ARX
+        else:
+            raise ValueError(
+                f"Unknown arm type: {name}, arm has to be one of the following: {ArmType.available_arms()}"
+            )
+        
+    def get_xml_path(self) -> str:
+        if self == ArmType.ARX:
+            return ARM_ARX_XML_PATH
+        elif self == ArmType.YAM:
+            return ARM_YAM_XML_PATH
+        else:
+            raise ValueError(f"Unknown arm type: {self}")
+
+
 class GripperType(enum.Enum):
     CRANK_4310 = "crank_4310"  # a 4310 motor with a crank
     LINEAR_3507 = "linear_3507"  # a 3507 motor with a linear actuator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "click<8.2.0",
     "dm-env==1.6",
     "evdev==1.9.2 ; sys_platform == 'linux'",
+    "mink>=0.0.13",
     "mujoco==3.3.5",
     "numpy==2.2.6",
     "portal==3.7.3",


### PR DESCRIPTION
This is done by combing the XML files from the gripper and the arm in i2rt/i2rt/robots/get_robot.py.