### PR TITLE
Add link6_mass override to support older teaching handles

### DIFF
--- a/i2rt/robots/get_robot.py
+++ b/i2rt/robots/get_robot.py
@@ -79,6 +79,7 @@ def get_yam_robot(
     zero_gravity_mode: bool = True,
     joint_state_saver_factory: Optional[Callable[[str], Any]] = None,
     set_realtime_and_pin_callback: Optional[Callable[[int], None]] = None,
+    link6_mass: float | None = None,
 ) -> MotorChainRobot:
     with_gripper = True
     with_teaching_handle = False
@@ -146,14 +147,19 @@ def get_yam_robot(
     )
 
     if with_gripper:
-        return get_robot(
+        robot = get_robot(
             gripper_index=6,
             gripper_limits=gripper_type.get_gripper_limits(),
             gripper_type=gripper_type,
             limit_gripper_force=50.0,
         )
     else:
-        return get_robot()
+        robot = get_robot()
+
+    if link6_mass is not None:
+        robot.kdl.set_body_mass("link_6", link6_mass)
+
+    return robot
 
 
 if __name__ == "__main__":

--- a/i2rt/utils/mujoco_utils.py
+++ b/i2rt/utils/mujoco_utils.py
@@ -40,3 +40,15 @@ class MuJoCoKDL:
         """
         assert gravity.shape == (3,)
         self.model.opt.gravity = gravity
+
+    def set_body_mass(self, body_name: str, mass: float) -> None:
+        """Sets the mass of a body in the model.
+
+        Args:
+            body_name (str): The name of the body.
+            mass (float): The new mass value in kg.
+        """
+        body_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+        if body_id == -1:
+            raise ValueError(f"Body '{body_name}' not found in model")
+        self.model.body_mass[body_id] = mass

--- a/scripts/minimum_gello.py
+++ b/scripts/minimum_gello.py
@@ -118,13 +118,15 @@ class Args:
     server_port: int = DEFAULT_ROBOT_PORT
     can_channel: str = "can0"
     bilateral_kp: float = 0.0
+    link6_mass: float | None = None
+    """Override the mass (kg) of link_6 for gravity compensation. Defaults to the value in the XML."""
 
 
 def main(args: Args) -> None:
     gripper_type = GripperType.from_string_name(args.gripper)
 
     if "remote" not in args.mode:
-        robot = get_yam_robot(channel=args.can_channel, gripper_type=gripper_type)
+        robot = get_yam_robot(channel=args.can_channel, gripper_type=gripper_type, link6_mass=args.link6_mass)
 
     if args.mode == "follower":
         server_robot = ServerRobot(robot, args.server_port)


### PR DESCRIPTION
Support for older 3D printed teaching handles was removed in https://github.com/i2rt-robotics/i2rt/commit/cbe48976b44aae45af856c62545be00ea2feed11 when the link 6 mass was changed to 0.258 kg. This PR adds a `--link6-mass` CLI argument to `minimum_gello.py` to override the link 6 mass at runtime, allowing arbitrary handle weights to be used without modifying the XML.