### PR TITLE
[Bug Fix] fix: initialize CAN channel and prevent duplicate DM control-loop thread start

### DIFF
--- a/i2rt/motor_drivers/can_interface.py
+++ b/i2rt/motor_drivers/can_interface.py
@@ -17,6 +17,7 @@ class CanInterface:
         receive_mode: ReceiveMode = ReceiveMode.p16,
         use_buffered_reader: bool = False,
     ):
+        self.channel = channel
         self.bus = can.interface.Bus(bustype=bustype, channel=channel, bitrate=bitrate)
         self.busstate = self.bus.state
         self.name = name

--- a/i2rt/motor_drivers/dm_driver.py
+++ b/i2rt/motor_drivers/dm_driver.py
@@ -510,7 +510,11 @@ class DMChainCanInterface(MotorChain):
         self.running = True
 
     def start_thread(self) -> None:
+        if self.start_thread_flag:
+            logging.info("control loop thread already started, skipping")
+            return
         logging.info("starting separate thread for control loop")
+        self.start_thread_flag = True
         thread = threading.Thread(target=self._set_torques_and_update_state)
         thread.start()
         time.sleep(0.1)

--- a/i2rt/robots/get_robot.py
+++ b/i2rt/robots/get_robot.py
@@ -215,10 +215,10 @@ def get_yam_robot(
 
     # --- Real hardware path ---------------------------------------------------
 
-    # Create chain with start_thread=True to avoid _motor_on() being called twice.
-    # The delayed start_thread() pattern (start_thread=False then manual start_thread())
-    # causes _motor_on() to re-initialize motors after offset correction, which disrupts
-    # the control loop and prevents motor positions from updating.
+    # Create chain with start_thread=True so thread lifecycle is handled in one place.
+    # _motor_on() runs during DMChainCanInterface initialization regardless of thread mode.
+    # Using the delayed pattern (start_thread=False then manual start_thread()) can trigger
+    # duplicate control-loop startup in downstream robot wiring and stale state updates.
     motor_chain = DMChainCanInterface(
         motor_list,
         motor_offsets,

--- a/i2rt/robots/get_robot.py
+++ b/i2rt/robots/get_robot.py
@@ -215,7 +215,10 @@ def get_yam_robot(
 
     # --- Real hardware path ---------------------------------------------------
 
-    # Single pass: create chain, read positions, fix wrap-around offsets in-place, then start thread.
+    # Create chain with start_thread=True to avoid _motor_on() being called twice.
+    # The delayed start_thread() pattern (start_thread=False then manual start_thread())
+    # causes _motor_on() to re-initialize motors after offset correction, which disrupts
+    # the control loop and prevents motor positions from updating.
     motor_chain = DMChainCanInterface(
         motor_list,
         motor_offsets,
@@ -223,14 +226,12 @@ def get_yam_robot(
         channel,
         motor_chain_name="yam_real",
         receive_mode=ReceiveMode.p16,
-        start_thread=False,
+        start_thread=True,
         get_same_bus_device_driver=get_encoder_chain if with_teaching_handle else None,
         use_buffered_reader=False,
     )
+    # Apply wrap-around offset correction after init.
     motor_states = motor_chain.read_states()
-    logging.debug(f"motor_states: {motor_states}")
-
-    logging.info(f"current_pos: {[m.pos for m in motor_states]}")
     for idx, state in enumerate(motor_states):
         if state.pos < -np.pi:
             logging.info(f"motor {idx} pos={state.pos:.3f}, offset -2π")
@@ -238,11 +239,6 @@ def get_yam_robot(
         elif state.pos > np.pi:
             logging.info(f"motor {idx} pos={state.pos:.3f}, offset +2π")
             motor_chain.motor_offset[idx] += 2 * np.pi
-
-    logging.info(f"adjusted motor_offsets: {motor_chain.motor_offset.tolist()}")
-
-    # Start the control thread with corrected offsets.
-    motor_chain.start_thread()
     logging.info(f"YAM initial motor_states: {motor_chain.read_states()}")
 
     get_robot = partial(

--- a/i2rt/robots/get_robot.py
+++ b/i2rt/robots/get_robot.py
@@ -215,10 +215,7 @@ def get_yam_robot(
 
     # --- Real hardware path ---------------------------------------------------
 
-    # Create chain with start_thread=True so thread lifecycle is handled in one place.
-    # _motor_on() runs during DMChainCanInterface initialization regardless of thread mode.
-    # Using the delayed pattern (start_thread=False then manual start_thread()) can trigger
-    # duplicate control-loop startup in downstream robot wiring and stale state updates.
+    # Single pass: create chain, read positions, fix wrap-around offsets in-place, then start thread.
     motor_chain = DMChainCanInterface(
         motor_list,
         motor_offsets,
@@ -226,12 +223,14 @@ def get_yam_robot(
         channel,
         motor_chain_name="yam_real",
         receive_mode=ReceiveMode.p16,
-        start_thread=True,
+        start_thread=False,
         get_same_bus_device_driver=get_encoder_chain if with_teaching_handle else None,
         use_buffered_reader=False,
     )
-    # Apply wrap-around offset correction after init.
     motor_states = motor_chain.read_states()
+    logging.debug(f"motor_states: {motor_states}")
+
+    logging.info(f"current_pos: {[m.pos for m in motor_states]}")
     for idx, state in enumerate(motor_states):
         if state.pos < -np.pi:
             logging.info(f"motor {idx} pos={state.pos:.3f}, offset -2π")
@@ -239,6 +238,11 @@ def get_yam_robot(
         elif state.pos > np.pi:
             logging.info(f"motor {idx} pos={state.pos:.3f}, offset +2π")
             motor_chain.motor_offset[idx] += 2 * np.pi
+
+    logging.info(f"adjusted motor_offsets: {motor_chain.motor_offset.tolist()}")
+
+    # Start the control thread with corrected offsets.
+    motor_chain.start_thread()
     logging.info(f"YAM initial motor_states: {motor_chain.read_states()}")
 
     get_robot = partial(


### PR DESCRIPTION
## What does this PR do?

This PR fixes two initialization and runtime stability issues in the robot stack:

1. Initializes the CAN channel attribute in the CAN interface constructor so channel state is always defined.
2. Makes control-loop startup idempotent in DMChainCanInterface by guarding start_thread() so the control thread is not started twice.

These changes improve startup reliability and prevent duplicate control-loop startup.

## Why is this needed?

- Missing or late channel attribute setup can cause inconsistent CAN interface state handling.
- Starting the control-loop thread multiple times can create unstable state updates and hard-to-debug hardware behavior.

## What files are changed?

- `can_interface.py`
- `dm_driver.py`

## How was this tested?

### Manual QA
- Ran full hardware test on Yam Ultra.
- Validated with the lerobot framework via Bi-Yam integration: https://github.com/huggingface/lerobot/pull/2920
- Validated with minimum_gello.py
- Confirmed startup is stable with no CAN channel initialization errors observed.
- Confirmed no duplicate control-loop startup in the tested workflow.

### Local validation
- Verified the fix scope is limited to CAN interface initialization and DM control-loop startup behavior.
- Focused automated tests: not run.
- Full test suite: not run.

## QA Result

PASS on Yam Ultra hardware and integration flows above.  
No regressions observed in startup/control-loop behavior during these runs.

## Risks and mitigations

- Risk: Changes touch startup and threading behavior in the motor control path.
- Mitigation: Scope is narrow, behavior is guarded and idempotent, and hardware validation was completed on Yam Ultra plus lerobot integration flow.

## Checklist

- [x] PR is scoped to one logical fix set.
- [x] No unrelated refactors included.
- [ ] Added or updated automated tests where appropriate.
- [x] QA steps completed and results recorded.

## Related commits

- fix(can_interface): initialize channel attribute in constructor
- fix(dm_driver): guard duplicate control-loop thread start