### PR TITLE
feat: add gripper gain and limit overrides to get_yam_robot

### DIFF
--- a/i2rt/motor_drivers/can_interface.py
+++ b/i2rt/motor_drivers/can_interface.py
@@ -17,6 +17,7 @@ class CanInterface:
         receive_mode: ReceiveMode = ReceiveMode.p16,
         use_buffered_reader: bool = False,
     ):
+        self.channel = channel
         self.bus = can.interface.Bus(bustype=bustype, channel=channel, bitrate=bitrate)
         self.busstate = self.bus.state
         self.name = name

--- a/i2rt/robots/get_robot.py
+++ b/i2rt/robots/get_robot.py
@@ -135,6 +135,8 @@ def get_yam_robot(
     ee_inertia: Optional[np.ndarray] = None,
     gravity_comp_factor: Optional[np.ndarray] = None,
     gripper_limits_override: Optional[np.ndarray] = None,
+    gripper_kp: Optional[float] = None,
+    gripper_kd: Optional[float] = None,
     sim: bool = False,
     joint_state_saver_factory: Optional[Callable[[], Any]] = None,
     set_realtime_and_pin_callback: Optional[Callable[[int], None]] = None,
@@ -151,6 +153,8 @@ def get_yam_robot(
         gravity_comp_factor: Per-joint array (6 elements, arm joints only) multiplied against gravity torques.
             Overrides the arm-type default when provided.
         gripper_limits_override: Optional [closed, open] limits. If provided, skips calibration.
+        gripper_kp: Optional gripper kp override. Defaults to gripper_type's default.
+        gripper_kd: Optional gripper kd override. Defaults to gripper_type's default.
         sim: If True, return a SimRobot instead of connecting to real hardware.
     """
     # --- Gripper-only path (no arm) -------------------------------------------
@@ -188,13 +192,15 @@ def get_yam_robot(
 
     if with_gripper:
         motor_type = gripper_type.get_motor_type(arm_type)
-        gripper_kp, gripper_kd = gripper_type.get_motor_kp_kd(arm_type)
-        logging.info(f"adding gripper motor type={motor_type}, kp={gripper_kp}, kd={gripper_kd}")
+        default_kp, default_kd = gripper_type.get_motor_kp_kd(arm_type)
+        _gripper_kp = gripper_kp if gripper_kp is not None else default_kp
+        _gripper_kd = gripper_kd if gripper_kd is not None else default_kd
+        logging.info(f"adding gripper motor type={motor_type}, kp={_gripper_kp}, kd={_gripper_kd}")
         motor_list.append([0x07, motor_type])
         motor_offsets.append(0.0)
         directions.append(gripper_type.get_motor_direction(arm_type))
-        kp = np.append(kp, gripper_kp)
-        kd = np.append(kd, gripper_kd)
+        kp = np.append(kp, _gripper_kp)
+        kd = np.append(kd, _gripper_kd)
 
     if gripper_limits_override is not None and with_gripper:
         gripper_limits = np.asarray(gripper_limits_override)

--- a/i2rt/robots/get_robot.py
+++ b/i2rt/robots/get_robot.py
@@ -134,6 +134,7 @@ def get_yam_robot(
     ee_mass: Optional[float] = None,
     ee_inertia: Optional[np.ndarray] = None,
     gravity_comp_factor: Optional[np.ndarray] = None,
+    gripper_limits_override: Optional[np.ndarray] = None,
     sim: bool = False,
     joint_state_saver_factory: Optional[Callable[[], Any]] = None,
     set_realtime_and_pin_callback: Optional[Callable[[int], None]] = None,
@@ -149,6 +150,7 @@ def get_yam_robot(
         ee_inertia: Optional 10-element inertia override [ipos(3), quat(4), diaginertia(3)].
         gravity_comp_factor: Per-joint array (6 elements, arm joints only) multiplied against gravity torques.
             Overrides the arm-type default when provided.
+        gripper_limits_override: Optional [closed, open] limits. If provided, skips calibration.
         sim: If True, return a SimRobot instead of connecting to real hardware.
     """
     # --- Gripper-only path (no arm) -------------------------------------------
@@ -194,8 +196,12 @@ def get_yam_robot(
         kp = np.append(kp, gripper_kp)
         kd = np.append(kd, gripper_kd)
 
-    gripper_limits = gripper_type.get_gripper_limits(arm_type) if with_gripper else None
-    gripper_needs_cal = gripper_type.get_gripper_needs_calibration(arm_type) if with_gripper else False
+    if gripper_limits_override is not None and with_gripper:
+        gripper_limits = np.asarray(gripper_limits_override)
+        gripper_needs_cal = False
+    else:
+        gripper_limits = gripper_type.get_gripper_limits(arm_type) if with_gripper else None
+        gripper_needs_cal = gripper_type.get_gripper_needs_calibration(arm_type) if with_gripper else False
 
     if sim:
         from i2rt.robots.sim_robot import SimRobot


### PR DESCRIPTION
  ## Summary
  - Add `gripper_kp`/`gripper_kd` parameter overrides to `get_yam_robot` for tuning gripper gains without modifying config files
  - Add `gripper_limits_override` to `get_yam_robot` to allow skipping gripper calibration
  - Fix: store `channel` attribute in `CanInterface` for passive encoder validation
