### PR TITLE
docs: sync with code updates

### DIFF
--- a/docs/examples/bimanual-teleoperation.md
+++ b/docs/examples/bimanual-teleoperation.md
@@ -85,8 +85,8 @@ The example launches two `minimum_gello.py` instances internally — one per arm
 
 ```python
 # Conceptually equivalent to:
-python examples/minimum_gello/minimum_gello.py --gripper linear_4310 --mode follower --can-channel can_follower_l --bilateral_kp 0.2
-python examples/minimum_gello/minimum_gello.py --gripper yam_teaching_handle --mode leader --can-channel can_leader_l --bilateral_kp 0.2
+python examples/minimum_gello/minimum_gello.py --gripper linear_4310 --mode follower --can-channel can_follower_l --bilateral-kp 0.2
+python examples/minimum_gello/minimum_gello.py --gripper yam_teaching_handle --mode leader --can-channel can_leader_l --bilateral-kp 0.2
 # (mirrored for right pair)
 ```
 
@@ -96,7 +96,7 @@ python examples/minimum_gello/minimum_gello.py --gripper yam_teaching_handle --m
 |---------|-----|
 | Missing CAN interface | Check `ip a`, replug adapters one at a time |
 | Arm not following | Ensure sync is enabled (top button) |
-| Jittery motion | Lower `--bilateral_kp` to `0.1` |
+| Jittery motion | Lower `--bilateral-kp` to `0.1` |
 | Motor timeout errors | Reduce loop latency; check USB-CAN adapter |
 
 ## See Also

--- a/docs/examples/record-replay.md
+++ b/docs/examples/record-replay.md
@@ -61,15 +61,21 @@ python examples/record_replay_trajectory/record_replay_trajectory.py --channel c
 
 ## Output Format
 
-Trajectories are saved as NumPy arrays:
+Trajectories are saved as a NumPy pickled dictionary (not a plain array):
 
 ```python
 import numpy as np
 
-# Shape: (T, 6) — T timesteps, 6 joints
-trajectory = np.load("trajectory.npy")
-print(trajectory.shape)  # (500, 6)
+data = np.load("trajectory.npy", allow_pickle=True).item()
+
+trajectory = data["trajectory"]   # np.ndarray, shape (T, 7) — T timesteps × joints
+timestamps = data["timestamps"]   # np.ndarray, shape (T,)   — seconds since epoch
+frequency  = data["frequency"]    # float — target control frequency in Hz
 ```
+
+::: warning `allow_pickle=True` required
+The file is saved with `np.save(path, dict)` which uses Python pickling. Loading with plain `np.load()` will raise a `ValueError`. Always pass `allow_pickle=True` and call `.item()` to extract the dict.
+:::
 
 ## See Also
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -69,7 +69,7 @@ python examples/minimum_gello/minimum_gello.py \
   --gripper linear_4310 \
   --mode follower \
   --can-channel can0 \
-  --bilateral_kp 0.2
+  --bilateral-kp 0.2
 ```
 
 **Terminal 2 — leader:**
@@ -79,7 +79,7 @@ python examples/minimum_gello/minimum_gello.py \
   --gripper yam_teaching_handle \
   --mode leader \
   --can-channel can1 \
-  --bilateral_kp 0.2
+  --bilateral-kp 0.2
 ```
 
 Press the **top button** on the teaching handle to enable synchronization.

--- a/docs/sdk/yam-arm.md
+++ b/docs/sdk/yam-arm.md
@@ -114,6 +114,42 @@ obs = robot.get_observations()
 #   obs["gripper_pos"] — (1,) gripper position
 #   obs["gripper_vel"] — (1,) gripper velocity
 #   obs["gripper_eff"] — (1,) gripper effort
+#
+# With temp_record_flag=True (passed to get_yam_robot):
+#   obs["temp_mos"]   — (N,) MOS temperature per motor (°C)
+#   obs["temp_rotor"] — (N,) rotor temperature per motor (°C)
+```
+
+Temperature fields are only included when the robot is constructed with `temp_record_flag=True` (pass via `get_yam_robot(..., temp_record_flag=True)`).
+
+### `get_robot_info() → dict`
+
+Returns robot configuration — useful for programmatic introspection (used internally by `ViserControlInterface` and `MujocoControlInterface`).
+
+```python
+info = robot.get_robot_info()
+# {
+#   "arm_type":           ArmType,
+#   "gripper_type":       GripperType,
+#   "kp":                 np.ndarray,   # (N,) PD position gains
+#   "kd":                 np.ndarray,   # (N,) PD velocity gains
+#   "grav_comp_kd":       np.ndarray,   # (N,) gravity-comp idle damping
+#   "coulomb_friction":   np.ndarray,   # (N,) Nm Coulomb friction
+#   "joint_limits":       np.ndarray,   # (2, N) [lower, upper] radians
+#   "gripper_limits":     np.ndarray,   # [closed, open] radians (or None)
+#   "gravity_comp_factor":np.ndarray,   # (6,) per-joint multiplier
+#   "gripper_index":      int | None,
+#   "limit_gripper_effort": float,      # only present when gripper_index is not None
+# }
+```
+
+### `get_motor_torques() → np.ndarray | None`
+
+Returns the last computed motor torques (gravity compensation + PD command torques combined) as sent to the hardware. Returns `None` before the first control loop iteration.
+
+```python
+torques = robot.get_motor_torques()
+# shape: (N,) Nm, one value per motor
 ```
 
 ### `move_joints(target, time_interval_s=2.0) → None`
@@ -147,6 +183,25 @@ robot.enter_gravity_comp_idle()  # arm floats again, with motor-side idle dampin
 ```
 
 The MuJoCo viewer (`examples/control_with_mujoco/`) calls this automatically on every CONTROL → VIS toggle. See [Gravity & Friction Compensation](/guides/gravity-compensation) for details.
+
+### `start_recording(save_dir: str) → bool`
+
+Starts asynchronous joint state recording to disk. Requires the robot to have been constructed with a `joint_state_saver_factory` (internal use — this is wired up automatically when using the bimanual `TwoArmEnv`).
+
+```python
+robot.start_recording("/tmp/session_001")
+```
+
+Raises `RuntimeError` if no saver factory was provided at construction.
+
+### `stop_recording(prefix: str = "") → tuple[bool, str]`
+
+Stops an active recording and returns `(success, message)`.
+
+```python
+ok, msg = robot.stop_recording(prefix="take_1")
+print(ok, msg)  # True  "Recording stopped successfully"
+```
 
 ### `close() → None`
 


### PR DESCRIPTION
## Summary
- **record-replay.md**: fix npy format docs — trajectory is a pickled dict (`{trajectory, timestamps, frequency}`), not a plain `(T,6)` array; load with `allow_pickle=True`
- **bilateral-kp**: `--bilateral_kp` → `--bilateral-kp` (tyro converts underscores to hyphens) in quick-start.md and bimanual-teleoperation.md
- **yam-arm SDK**: document missing public methods — `get_robot_info()`, `get_motor_torques()`, `start_recording()`, `stop_recording()`, plus the `temp_mos`/`temp_rotor` keys returned by `get_observations()` when `temp_record_flag=True`

All changes verified against `i2rt/robots/motor_chain_robot.py` and `examples/record_replay_trajectory/`.

## Test plan
- [x] Local preview verified at localhost:4173
- [x] Build passes
- [x] All signatures match code (see verification in PR thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)