### PR TITLE
Release v1.1.2-hotfix

### DIFF
--- a/i2rt/robots/config/crank_4310.yml
+++ b/i2rt/robots/config/crank_4310.yml
@@ -21,9 +21,9 @@ motor_type: "DM4310"
 motor_kp: 20.0
 motor_kd: 0.5
 
-# Gripper limits
-gripper_limits: [0.0, -2.7]
-needs_calibration: false
+# Gripper limits — null triggers runtime auto-calibration (see motor_chain_robot.py)
+gripper_limits: null
+needs_calibration: true
 
 # Force limiter config
 limiter:


### PR DESCRIPTION
## Summary

Hotfix on top of v1.1.2: the `crank_4310` gripper now auto-calibrates at runtime instead of relying on hardcoded limits. Produced by mirroring `dev/JH_i2rt` into the public repo (git-ignored files excluded).

## Changes

- i2rt/robots/config/crank_4310.yml: set `gripper_limits: null` and `needs_calibration: true` so the crank_4310 gripper triggers runtime auto-calibration (see `motor_chain_robot.py`) instead of the previous hardcoded `[0.0, -2.7]` limits

## Test Plan

- [x] `uv sync --all-packages` in a fresh checkout succeeds
- [x] `python -c "import i2rt"` imports cleanly
- [ ] Bring up a crank_4310 gripper and confirm it runs the auto-calibration routine on startup (no hardcoded limits applied)
- [ ] Confirm the diff touches only `crank_4310.yml` — no other robot config changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)