### PR TITLE
Fix README CLI-flag docs and markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,17 @@ sh scripts/reset_all_can.sh
 ### Zero-gravity mode
 
 ```bash
-python i2rt/robots/motor_chain_robot.py --channel can0 --gripper_type linear_4310
+python i2rt/robots/motor_chain_robot.py --channel can0 --gripper linear_4310
 ```
 
 ### Python API
 
 ```python
-from i2rt.robots.motor_chain_robot import get_yam_robot
+from i2rt.robots.get_robot import get_yam_robot
+from i2rt.robots.utils import GripperType
 import numpy as np
 
-robot = get_yam_robot(channel="can0", gripper_type="linear_4310")
+robot = get_yam_robot(channel="can0", gripper_type=GripperType.LINEAR_4310)
 
 # Read joint positions (radians)
 q = robot.get_joint_pos()   # shape: (6,)
@@ -72,15 +73,15 @@ robot.command_joint_pos(np.zeros(6))
 
 ```bash
 # Follower arm
-python examples/minimum_gello/minimum_gello.py --gripper linear_4310 --mode follower --can-channel can0 --bilateral_kp 0.2
+python examples/minimum_gello/minimum_gello.py --gripper linear_4310 --mode follower --can-channel can0 --bilateral-kp 0.2
 
 # Leader arm (teaching handle)
-python examples/minimum_gello/minimum_gello.py --gripper yam_teaching_handle --mode leader --can-channel can1 --bilateral_kp 0.2
+python examples/minimum_gello/minimum_gello.py --gripper yam_teaching_handle --mode leader --can-channel can1 --bilateral-kp 0.2
 ```
 
 - **Top button (press once):** enable synchronisation — follower tracks leader
 - **Top button (press again):** disable synchronisation
-- `--bilateral_kp` controls resistance felt on the leader (0.1–0.2 recommended)
+- `--bilateral-kp` controls resistance felt on the leader (0.1–0.2 recommended)
 
 To inspect leader arm output:
 

--- a/devices/pi_setup.md
+++ b/devices/pi_setup.md
@@ -23,8 +23,12 @@ sync
 
 ### 4. Eject SD card
 
-```bash eject /dev/sdX ```
+```bash
+eject /dev/sdX
+```
 
 ### 5. Reduce image size with PiShrink (optional)
 
-```bash sudo ./pishrink.sh pi_system.img pi_system_shrunk.img ```
+```bash
+sudo ./pishrink.sh pi_system.img pi_system_shrunk.img
+```

--- a/examples/bimanual_lead_follower/README.md
+++ b/examples/bimanual_lead_follower/README.md
@@ -18,7 +18,7 @@ This tutorial demonstrates how to set up a bimanual lead-follower system. This t
 
 **⚠️ Critical Step:** Plug in **one CAN device at a time** to avoid conflicts.
 
-1. Follow the instructions in [set_persist_id_socket_can.md](../../doc/set_persist_id_socket_can.md) to configure each arm:
+1. Follow the instructions in [set-persistent-can-ids.md](../../docs/guides/set-persistent-can-ids.md) to configure each arm:
    - **Left leader arm:** `can_leader_l`
    - **Right leader arm:** `can_leader_r`
    - **Left follower arm:** `can_follower_l`

--- a/examples/control_with_mujoco/README.md
+++ b/examples/control_with_mujoco/README.md
@@ -38,12 +38,12 @@ python examples/control_with_mujoco/control_with_mujoco.py --arm big_yam --gripp
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `--arm` | `yam` | Arm type: `yam`, `yam_pro`, `yam_ultra`, `big_yam` |
-| `--gripper` | `linear_4310` | Gripper type: `linear_4310`, `linear_3507`, `crank_4310`, `yam_teaching_handle`, `no_gripper` |
+| `--arm` | `yam` | Arm type: `yam`, `yam_pro`, `yam_ultra`, `big_yam`, `no_arm` (gripper-only; cannot combine with `--gripper no_gripper`) |
+| `--gripper` | `linear_4310` | Gripper type: `linear_4310`, `linear_3507`, `crank_4310`, `flexible_4310`, `yam_teaching_handle`, `no_gripper` |
 | `--channel` | `can0` | CAN interface name (real hardware only) |
 | `--sim` | off | Use simulation instead of real hardware |
 | `--dt` | `0.02` | Control loop timestep in seconds |
-| `--site` | `grasp_site` | Name of the MuJoCo site used as end-effector |
+| `--site` | auto | MuJoCo site used as end-effector (auto-detected from gripper: `tcp_site` for `yam_teaching_handle`, else `grasp_site`) |
 | `--log` | off | Log joint state and torques to terminal each iteration |
 
 ## Viewer Controls (CONTROL mode)

--- a/examples/control_with_viser/README.md
+++ b/examples/control_with_viser/README.md
@@ -48,7 +48,7 @@ Directly control each joint angle (in degrees) and the gripper position using in
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--arm` | `yam` | Arm variant (`yam`, `yam_pro`, `yam_ultra`, `big_yam`) |
-| `--gripper` | `linear_4310` | Gripper type (`linear_4310`, `linear_3507`, `crank_4310`, `no_gripper`, `yam_teaching_handle`) |
+| `--gripper` | `linear_4310` | Gripper type (`linear_4310`, `linear_3507`, `crank_4310`, `flexible_4310`, `no_gripper`, `yam_teaching_handle`) |
 | `--channel` | `can0` | CAN interface name (ignored in sim mode) |
 | `--sim` | off | Use simulated robot instead of real hardware |
 | `--dt` | `0.02` | Control loop timestep in seconds |

--- a/examples/control_with_viser/control_with_viser.py
+++ b/examples/control_with_viser/control_with_viser.py
@@ -22,7 +22,7 @@ from i2rt.robots.utils import ArmType, GripperType
 from i2rt.utils.viser_control_interface import ViserControlInterface
 
 if __name__ == "__main__":
-    arm_choices = [a.value for a in ArmType]
+    arm_choices = [a.value for a in ArmType if a != ArmType.NO_ARM]
     gripper_choices = [g.value for g in GripperType]
 
     parser = argparse.ArgumentParser(description="Viser control interface for i2rt robots")

--- a/examples/single_motor_position_pd_control/README.md
+++ b/examples/single_motor_position_pd_control/README.md
@@ -14,7 +14,7 @@ This example demonstrates a simple interface to control a single motor using you
 Run the script from the command line:
 
 ```bash
-python i2rt/scripts/single_motor_pd_pos_control.py --channel can1 --motor_id 1 --kd 5
+python examples/single_motor_position_pd_control/single_motor_position_pd_control.py --channel can1 --motor_id 1 --kd 5
 ```
 
 You will see example panel like this:

--- a/i2rt/flow_base/README.md
+++ b/i2rt/flow_base/README.md
@@ -71,7 +71,7 @@ The exposed RJ45 network interface is preconfigured with static IP `172.6.2.20`.
 - The base has motion control limits with maximum acceleration constraints
 - When you release the joystick (sending 0 command), the base won't stop immediately due to physics
 - Always ensure the remote is awake when running API experiments - Left2 can override unexpected code behavior
-- Speed and acceleration settings can be adjusted in [flow_base_controller](flow_base_controller.py#L500-L501)
+- Speed and acceleration settings can be adjusted in [flow_base_controller](flow_base_controller.py#L742-L743)
 
 ⚠️ **Warning**: Setting overly aggressive speed or acceleration parameters can cause system instability.
 


### PR DESCRIPTION
## Summary

Corrects documentation defects across the repo's READMEs that were found by auditing every documented CLI command/flag against the actual arg parsers, plus two markdown-rendering/link fixes. Also makes one small source change so the viser tool rejects an arm choice that produces a degenerate (dead-IK) session. Several of these were hard breaks — documented commands that fail outright (wrong flag name, wrong script path, broken Python import).

## Changes

- devices/pi_setup.md: split two malformed single-line code fences (` ```bash ... ``` `) into proper multi-line blocks; the unclosed fence made the rest of the doc render as one code block
- examples/bimanual_lead_follower/README.md: repoint broken link from the moved guide `../../doc/set_persist_id_socket_can.md` to `../../docs/guides/set-persistent-can-ids.md`
- i2rt/flow_base/README.md: fix speed/accel source link anchor `#L500-L501` -> `#L742-L743` (the actual `max_vel`/`max_accel` definitions)
- README.md: fix CLI flag `--gripper_type` -> `--gripper` (motor_chain_robot defines `--gripper`); fix Python API import to `i2rt.robots.get_robot` and pass `GripperType.LINEAR_4310` (a string raised `AttributeError` via `gripper_type.get_xml_path()`); use the canonical tyro flag `--bilateral-kp`
- examples/control_with_mujoco/README.md: add `no_arm` to `--arm` and `flexible_4310` to `--gripper` (choices are built from the full enums); correct `--site` (default is auto-detected from gripper, not `grasp_site`)
- examples/control_with_viser/control_with_viser.py: exclude `ArmType.NO_ARM` from `--arm` choices; the viewer's IK and arm-joint modes are degenerate with no arm (`_n_arm=0`)
- examples/control_with_viser/README.md: add `flexible_4310` to `--gripper`; keep `--arm` at the four supported variants to match the restricted choices
- examples/single_motor_position_pd_control/README.md: correct script path to `examples/single_motor_position_pd_control/single_motor_position_pd_control.py` (was a non-existent `i2rt/scripts/single_motor_pd_pos_control.py`)

## Test Plan

- [ ] **Markdown render (GitHub):** open `devices/pi_setup.md` in the PR diff and confirm sections 4 & 5 render as real code blocks (not one giant block); confirm the bimanual link and the flow_base `#L742-L743` anchor both resolve.
- [ ] **viser choices (no hardware):** `python examples/control_with_viser/control_with_viser.py --help` shows `--arm {yam,yam_pro,yam_ultra,big_yam}` and `flexible_4310` in `--gripper`; `python examples/control_with_viser/control_with_viser.py --arm no_arm --sim` exits with `error: argument --arm: invalid choice: 'no_arm'`.
- [ ] **mujoco choices (no hardware):** `python examples/control_with_mujoco/control_with_mujoco.py --help` shows `no_arm` in `--arm` and `flexible_4310` in `--gripper`.
- [ ] **minimum_gello flag (no hardware):** `python examples/minimum_gello/minimum_gello.py --help` lists `--bilateral-kp` (and accepts it).
- [ ] **single_motor path:** `examples/single_motor_position_pd_control/single_motor_position_pd_control.py` exists and defines `--channel`, `--motor_id`, `--kd`.
- [ ] **Python API (full env):** `python -c "from i2rt.robots.get_robot import get_yam_robot; from i2rt.robots.utils import GripperType; get_yam_robot(channel='can0', gripper_type=GripperType.LINEAR_4310, sim=True)"` runs with no `ImportError`/`AttributeError`.
- [ ] **Hardware (optional):** on a station with CAN, `python i2rt/robots/motor_chain_robot.py --channel can0 --gripper linear_4310` starts in zero-gravity mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
