### PR TITLE
fix(devices): correct desktop icon relative path for Desktop install location

### DIFF
--- a/devices/FlowBase.desktop
+++ b/devices/FlowBase.desktop
@@ -3,6 +3,6 @@ Type=Application
 Name=FlowBase
 Comment=Run FlowBase with base only (8 motors, no linear rail)
 Exec=lxterminal -e "bash -c '/home/i2rt/i2rt/.venv/bin/python /home/i2rt/i2rt/i2rt/flow_base/flow_base_controller.py --channel can0; echo; echo \"Process finished. Press Enter to close...\"; read'"
-Icon=../i2rt/flow_base/assets/flow_base.png
+Icon=../i2rt/i2rt/flow_base/assets/flow_base.png
 Terminal=true
 Categories=Utility;

--- a/devices/FlowBaseGamepad.desktop
+++ b/devices/FlowBaseGamepad.desktop
@@ -3,6 +3,6 @@ Type=Application
 Name=FlowBase (Gamepad)
 Comment=Run FlowBase with base only (8 motors, no linear rail) and gamepad teleop
 Exec=lxterminal -e "bash -c '/home/i2rt/i2rt/.venv/bin/python /home/i2rt/i2rt/i2rt/flow_base/flow_base_controller.py --channel can0 --gamepad; echo; echo \"Process finished. Press Enter to close...\"; read'"
-Icon=../i2rt/flow_base/assets/flow_base.png
+Icon=../i2rt/i2rt/flow_base/assets/flow_base.png
 Terminal=true
 Categories=Utility;

--- a/devices/LinearRailVehicle.desktop
+++ b/devices/LinearRailVehicle.desktop
@@ -3,7 +3,7 @@ Type=Application
 Name=LinearRailVehicle
 Comment=Run FlowBase with linear rail (9 motors: 8 base + 1 linear rail)
 Exec=lxterminal -e "bash -c '/home/i2rt/i2rt/.venv/bin/python /home/i2rt/i2rt/i2rt/flow_base/flow_base_controller.py --channel can0 --linear-rail; echo; echo \"Process finished. Press Enter to close...\"; read'"
-Icon=../i2rt/flow_base/assets/linear_rail.png
+Icon=../i2rt/i2rt/flow_base/assets/linear_rail.png
 Terminal=true
 Categories=Utility;
 

--- a/devices/LinearRailVehicleGamepad.desktop
+++ b/devices/LinearRailVehicleGamepad.desktop
@@ -3,6 +3,6 @@ Type=Application
 Name=LinearRailVehicle (Gamepad)
 Comment=Run FlowBase with linear rail (9 motors: 8 base + 1 linear rail) and gamepad teleop
 Exec=lxterminal -e "bash -c '/home/i2rt/i2rt/.venv/bin/python /home/i2rt/i2rt/i2rt/flow_base/flow_base_controller.py --channel can0 --linear-rail --gamepad; echo; echo \"Process finished. Press Enter to close...\"; read'"
-Icon=../i2rt/flow_base/assets/linear_rail.png
+Icon=../i2rt/i2rt/flow_base/assets/linear_rail.png
 Terminal=true
 Categories=Utility;


### PR DESCRIPTION
## Summary

The `.desktop` launcher files install to `/home/i2rt/Desktop` while the repo is cloned to `/home/i2rt/i2rt`. The `Icon=` paths were relative to the file's in-repo location (`devices/`), so they broke once the files were copied to the Desktop. This corrects the relative `Icon=` paths to resolve from `/home/i2rt/Desktop` to the icon assets in the repo.

## Changes

- devices/FlowBase.desktop: update `Icon=` to `../i2rt/i2rt/flow_base/assets/flow_base.png` so it resolves from `/home/i2rt/Desktop` to `/home/i2rt/i2rt/i2rt/flow_base/assets/flow_base.png`
- devices/FlowBaseGamepad.desktop: same `Icon=` path correction (flow_base.png)
- devices/LinearRailVehicle.desktop: update `Icon=` to `../i2rt/i2rt/flow_base/assets/linear_rail.png` for the new install location
- devices/LinearRailVehicleGamepad.desktop: same `Icon=` path correction (linear_rail.png)

## Test Plan

- [ ] Clone the repo to `/home/i2rt/i2rt` and copy the four files from `devices/` into `/home/i2rt/Desktop`.
- [ ] Confirm `/home/i2rt/i2rt/i2rt/flow_base/assets/flow_base.png` and `linear_rail.png` exist.
- [ ] From `/home/i2rt/Desktop`, run `readlink -f ../i2rt/i2rt/flow_base/assets/flow_base.png` and verify it resolves to the file above.
- [ ] Open the file manager / desktop and confirm each launcher shows its icon (FlowBase + Gamepad → flow_base.png; LinearRailVehicle + Gamepad → linear_rail.png).
- [ ] Edge case: if a desktop environment ignores relative `Icon=` paths, note that absolute paths may be required (per-spec, `Icon=` expects an absolute path or a bare theme name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)