### PR TITLE
[ROB-1464] fix(linear_rail): keep brake engaged after a single shutdown

### DIFF
--- a/i2rt/flow_base/linear_rail_controller.py
+++ b/i2rt/flow_base/linear_rail_controller.py
@@ -174,6 +174,7 @@ class LinearRailController:
         self.lower_limit_triggered = False
         self._gpio_mode_set = False
         self._gpio_initialized = False  # Flag to prevent duplicate GPIO initialization
+        self._cleaned_up = False  # Idempotency guard: a 2nd cleanup() is a no-op (no port reopen)
         self._homing_event = threading.Event()
         self._homing_start_time = None
         self.homing_speed_ratio = HOMING_SPEED_RATIO
@@ -547,19 +548,38 @@ class LinearRailController:
                 raise
 
     def cleanup(self) -> None:
-        """Clean up resources"""
+        """Clean up resources, leaving the rail held (brake engaged LOW).
+
+        Idempotent: a second call returns immediately. The standalone runner closes the
+        vehicle twice (a ``finally:`` close plus an ``atexit`` close); without this guard
+        the second pass would reopen the serial port (a converter reset that briefly
+        disturbs the brake) before re-engaging. The motor stop is isolated from the brake
+        engage so a CAN error stopping the motor cannot skip the safety-critical engage.
+        """
+        if self._cleaned_up:
+            return
+        self._cleaned_up = True
+
+        # Stop the rail motor (best effort). Isolated so a CAN failure here cannot
+        # prevent the brake engage below.
         try:
             self.single_motor_control_interface.set_velocity(0.0)
-            if self.initialized:
-                # Ensure GPIO mode is set before cleanup operations
-                try:
-                    self._ensure_gpio_mode()
-                    self.set_brake(engaged=True)
-                    GPIO.remove_event_detect(UPPER_LIMIT_GPIO)
-                    GPIO.remove_event_detect(LOWER_LIMIT_GPIO)
-                    GPIO.cleanup()
-                except Exception as gpio_error:
-                    logger.warning(f"GPIO cleanup error (may be expected if GPIO was not initialized): {gpio_error}")
-            logger.info("Linear rail controller cleaned up successfully")
         except Exception as e:
-            logger.error(f"Cleanup error: {e}")
+            logger.error(f"Failed to stop linear-rail motor during cleanup: {e}")
+
+        if self.initialized:
+            # Ensure GPIO mode is set before cleanup operations
+            try:
+                self._ensure_gpio_mode()
+                self.set_brake(engaged=True)  # drive brake LOW (engaged) and leave it latched
+                GPIO.remove_event_detect(UPPER_LIMIT_GPIO)
+                GPIO.remove_event_detect(LOWER_LIMIT_GPIO)
+                # Tear down ONLY the limit-switch INPUT pins. On the Pi this leaves the brake
+                # OUTPUT pin (12) driven LOW (engaged) instead of floating it; on x86 the
+                # backend ignores the pin arg, closes the port, and the converter latches the
+                # brake at its last-driven LOW level across the close.
+                GPIO.cleanup((UPPER_LIMIT_GPIO, LOWER_LIMIT_GPIO))
+            except Exception as gpio_error:
+                logger.warning(f"GPIO cleanup error (may be expected if GPIO was not initialized): {gpio_error}")
+
+        logger.info("Linear rail controller cleaned up successfully")

--- a/i2rt/utils/tests/test_usb_gpio_driver.py
+++ b/i2rt/utils/tests/test_usb_gpio_driver.py
@@ -140,9 +140,10 @@ def test_output_resends_then_warns_on_wrong_echo(
     assert any("not confirmed by echo" in record.message for record in caplog.records)
 
 
-def test_cleanup_releases_output_channels(fake_serial: dict[str, Any]) -> None:
-    # Mirror RPi.GPIO.cleanup(): configured OUTPUT channels are driven to their
-    # released level (HIGH) on cleanup so the brake ends up released, not held.
+def test_cleanup_keeps_brake_latched_low_not_released(fake_serial: dict[str, Any]) -> None:
+    # The converter latches its last-driven level across a port close, so cleanup()
+    # must NOT drive outputs HIGH (released): a brake engaged LOW stays engaged after
+    # shutdown, holding the rail. Regression guard for brake-released-on-shutdown.
     fake_serial["levels"][3] = False
     backend = UsbGpioBackend("/dev/ttyFAKE", pin_map=PIN_MAP)
     backend.setmode(backend.BCM)
@@ -151,8 +152,22 @@ def test_cleanup_releases_output_channels(fake_serial: dict[str, Any]) -> None:
     serial_obj = backend._dev._serial
     backend.cleanup()
     sets = _set_writes(fake_serial)
-    assert sets[-1] == bytes.fromhex("3a 03 01")  # last write released ch3 (HIGH)
+    assert sets[-1] == bytes.fromhex("3a 03 00")  # last brake write stayed LOW (engaged)
+    assert bytes.fromhex("3a 03 01") not in sets  # cleanup never released ch3 (HIGH)
     assert serial_obj.is_open is False
+
+
+def test_cleanup_accepts_pin_tuple_and_tears_down(fake_serial: dict[str, Any]) -> None:
+    # LinearRailController.cleanup() calls GPIO.cleanup((UPPER, LOWER)); on x86 the backend
+    # must accept and ignore the tuple arg and still fully tear down the shared port.
+    backend = UsbGpioBackend("/dev/ttyFAKE", pin_map=PIN_MAP)
+    backend.setmode(backend.BCM)
+    backend.setup(BRAKE, backend.OUT)
+    backend.output(BRAKE, backend.LOW)
+    serial_obj = backend._dev._serial
+    backend.cleanup((UPPER, LOWER))  # tuple arg, as the controller passes
+    assert serial_obj.is_open is False
+    assert backend._dev is None
 
 
 # -- UsbGpioBackend.input ------------------------------------------------------

--- a/i2rt/utils/usb_gpio_driver.py
+++ b/i2rt/utils/usb_gpio_driver.py
@@ -376,23 +376,20 @@ class UsbGpioBackend:
             self._stop_poll_thread()
 
     def cleanup(self, pin: Optional[int] = None) -> None:
-        # Stop polling, release outputs, then close the serial port. Native
-        # RPi.GPIO.cleanup() resets pins to floating inputs, so the brake ends up
-        # released on the Pi. The converter instead latches its last-driven level,
-        # so to match the Pi we explicitly drive every configured OUTPUT channel to
-        # its released level (HIGH) before closing (brake released on shutdown).
+        # Stop polling and close the serial port. The converter LATCHES its last-driven
+        # level across a port close, so we deliberately do NOT touch the output channels
+        # here: the brake stays at its last commanded level (LOW == engaged; see
+        # set_brake_gpio) and the rail stays held after a single shutdown. (Native
+        # RPi.GPIO.cleanup() floats pins instead, releasing the brake on a Pi -- the
+        # controller avoids that by cleaning up only the limit-switch input pins.) ``pin``
+        # is accepted for RPi.GPIO API compatibility but ignored: cleanup() is only ever
+        # called at process shutdown, where full teardown of the single shared port is the
+        # only correct action.
         self._stop_poll_thread()  # join FIRST (outside locks) before clearing watch state
         with self._watch_lock:
             self._watch.clear()
             self._last_stable.clear()
             self._last_change_ts.clear()
-        if self._dev is not None:
-            for out_pin, direction in self._directions.items():
-                if direction == self.OUT:
-                    try:
-                        self.output(out_pin, self.HIGH)  # HIGH == released (see set_brake_gpio)
-                    except Exception as e:
-                        logger.warning(f"USB-GPIO cleanup: failed to release output pin {out_pin}: {e}")
         self._directions.clear()
         self._pulls.clear()
         with self._serial_lock:


### PR DESCRIPTION
## Summary

On the consolidated single-host LinearBot (x86; brake driven through the bestep USB-to-GPIO converter, not a Raspberry Pi), stopping the controller left the vertical rail brake **RELEASED**, so the rail could drift/drop. The standalone runner only appeared to work because it closes the vehicle twice; any caller that closes once (e.g. lab42) ended up with the brake released. A **single** `LinearRailController.cleanup()` / `LinearRailVehicle.close()` now leaves the brake **ENGAGED (GPIO LOW)** on both x86 and Raspberry Pi, with no dependence on a second call and no serial-port reopen.

Root cause: `cleanup()` engaged the brake (drove it LOW), then `GPIO.cleanup()` undid it — on x86 `UsbGpioBackend.cleanup()` deliberately drove every configured OUTPUT channel HIGH (released), and on the Pi the global `RPi.GPIO.cleanup()` floats all pins. Net result of one cleanup = brake released.

**Safety note:** brake polarity is LOW = engaged/held (unchanged — `set_brake(engaged=True)` already commanded LOW; this PR only stops `cleanup()` from overriding it back to HIGH). Steady state after a single close = the same latched LOW the standalone double-close already holds the rail in. Software cannot guarantee the level survives a hard kill / power loss / USB unplug — that depends on the brake being spring-engaged (power-to-release). Scope is brake-only; rail-motor / CAN-loop shutdown behavior is intentionally unchanged.

## Changes

- `i2rt/utils/usb_gpio_driver.py`: `UsbGpioBackend.cleanup()` no longer drives configured OUTPUT channels HIGH (released) on shutdown. The converter latches its last-driven level across a port close, so the brake stays at its last commanded level (LOW = engaged) and the rail stays held. Rewrote the misleading comment.
- `i2rt/flow_base/linear_rail_controller.py`: `LinearRailController.cleanup()` is now idempotent (a 2nd call is a no-op, so the standalone double-close no longer reopens the serial port and resets the converter); `set_velocity(0.0)` is isolated in its own `try/except` so a CAN error can't skip the safety-critical brake engage; replaced global `GPIO.cleanup()` with `GPIO.cleanup((UPPER_LIMIT_GPIO, LOWER_LIMIT_GPIO))` so on the Pi the brake OUTPUT pin stays driven LOW instead of being floated. Added a `_cleaned_up` guard flag in `__init__`.
- `i2rt/utils/tests/test_usb_gpio_driver.py`: inverted the cleanup test (`test_cleanup_keeps_brake_latched_low_not_released`) to assert the brake stays LOW and cleanup issues no HIGH to the brake channel; added `test_cleanup_accepts_pin_tuple_and_tears_down` for the limit-pin tuple the controller now passes.

## Test Plan

### Unit tests (x86, no hardware — runs in CI)
- [ ] `uv run pytest i2rt/utils/tests/test_usb_gpio_driver.py -q` — 21 pass, incl. `test_cleanup_keeps_brake_latched_low_not_released` and `test_cleanup_accepts_pin_tuple_and_tears_down`.
- [ ] `uv run pytest -n auto` — full suite green (expected: 281 passed, 2 skipped).
- [ ] `uv run ruff check .` — clean.

### Manual on x86 (the reported failure)
- [ ] Bring up `LinearRailVehicle(enable_linear_rail=True, usb_gpio_device="/dev/ttyUSB0", ...)` and call `vehicle.close()` exactly **once**.
- [ ] Confirm converter channel 3 reads **LOW** and the brake physically holds — the rail does not drift/drop.

### Standalone runner
- [ ] `python i2rt/flow_base/flow_base_controller.py --linear-rail --device /dev/ttyUSB0`, then Ctrl-C.
- [ ] Confirm the brake stays engaged and there is no port-reopen / board-reset glitch on shutdown.

### Regression / parity
- [ ] Run with `enable_linear_rail=False` — base-motor behavior unchanged.
- [ ] (If a Pi is available) confirm pin 12 stays driven LOW after a single close (note: subject to the installed GPIO library's process-exit semantics; the x86 converter is the primary target).

Related to ROB-1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)