### PR TITLE
[ROB-1511] feat(flow_base): expose all motor pos/vel/torque in observation

### DIFF
--- a/i2rt/flow_base/README.md
+++ b/i2rt/flow_base/README.md
@@ -136,23 +136,39 @@ python i2rt/flow_base/flow_base_client.py --command test_linear_rail --host 172.
 python i2rt/flow_base/flow_base_client.py --command get_linear_rail_state --host 172.6.2.20
 ```
 
-**Get Combined Observation** (odometry, plus linear rail when `--with-linear-rail` is set):
+**Get Combined Observation** (odometry + wheel states, plus linear rail when `--with-linear-rail` is set):
 ```bash
-# Odometry only
+# Odometry + wheel states
 python i2rt/flow_base/flow_base_client.py --command get_observation --host 172.6.2.20
 
-# Odometry + linear rail
+# Odometry + wheel states + linear rail
 python i2rt/flow_base/flow_base_client.py --command get_observation --host 172.6.2.20 --with-linear-rail
 ```
 
 **Output (with `--with-linear-rail`):**
 ```python
 {
-  'odometry':    { ... same shape as get_odometry ... },
-  'linear_rail': { ... same shape as get_linear_rail_state ... },
+  'odometry':     { ... same shape as get_odometry ... },
+  'wheel_states': { ... same shape as get_wheel_states ... },
+  'linear_rail':  { ... same shape as get_linear_rail_state ... },
 }
 ```
-Without the flag, only the `odometry` key is returned.
+Without the flag, the `linear_rail` key is omitted; `odometry` and `wheel_states` are always returned.
+
+**Get Wheel States** (per-motor pos/vel/torque for the 8 base motors):
+```bash
+python i2rt/flow_base/flow_base_client.py --command get_wheel_states --host 172.6.2.20
+```
+
+**`get_wheel_states()` output:**
+```python
+{
+  'steer': {'pos': array([..4]), 'vel': array([..4]), 'eff': array([..4])},  # rad, rad/s, Nm
+  'drive': {'pos': array([..4]), 'vel': array([..4]), 'eff': array([..4])},  # rad, rad/s, Nm
+}
+```
+`eff` is motor torque in Nm. The 4 entries per group are the casters in chain order; the linear
+rail (9th) motor is reported separately by `get_linear_rail_state()`.
 
 ### Linear Rail API (if equipped)
 
@@ -162,7 +178,7 @@ If your FlowBase has a linear rail lift module installed, you can control it via
 - `get_linear_rail_state()` - Get position, velocity, limit-switch and calibration state
 - `set_linear_rail_velocity(velocity)` - Set linear velocity in m/s (positive = up; converted to motor rad/s server-side using the calibrated `meters_per_rad`)
 - `set_target_velocity([x, y, theta, rail_vel], frame)` - Combined base + rail control (4D; `rail_vel` in m/s)
-- `get_observation()` - Returns `{odometry, linear_rail}` (the `linear_rail` key is included only when `with_linear_rail=True`)
+- `get_observation()` - Returns `{odometry, wheel_states, linear_rail}` (the `linear_rail` key is included only when `with_linear_rail=True`)
 
 Initialize with `FlowBaseClient(host="172.6.2.20", with_linear_rail=True)` to enable linear rail support.
 
@@ -176,6 +192,7 @@ hard caps `1.0 / 1.0 / π / 1.0` (values outside `(0, cap]` raise `ValueError`).
 {
   'position': {'motor': 0.314, 'linear': 0.050},   # rad, m
   'velocity': {'motor': -1.40, 'linear': -0.222},  # rad/s, m/s
+  'eff': 0.85,                                      # Nm, rail motor torque
   'upper_limit_triggered': False,
   'lower_limit_triggered': False,
   'brake_on': False,

--- a/i2rt/flow_base/flow_base_client.py
+++ b/i2rt/flow_base/flow_base_client.py
@@ -64,16 +64,19 @@ class FlowBaseClient:
     def get_odometry(self) -> Any:
         return self.client.get_odometry({}).result()
 
-    def get_wheel_speeds(self) -> Any:
-        """Return per-motor angular velocities (rad/s) for the 4 casters: {steer, drive}."""
-        return self.client.get_wheel_speeds({}).result()
+    def get_wheel_states(self) -> Any:
+        """Return full per-motor state for the 8 base motors, grouped {steer, drive}.
+
+        Each group has pos (rad), vel (rad/s), and eff (torque, Nm) arrays of length 4.
+        """
+        return self.client.get_wheel_states({}).result()
 
     def get_observation(self) -> Any:
-        """Return combined observation: odometry, wheel speeds, and linear rail state if enabled."""
+        """Return combined observation: odometry, wheel states, and linear rail state if enabled."""
         obs: dict[str, Any] = {"odometry": self.get_odometry()}
         if self.with_linear_rail:
             obs["linear_rail"] = self.get_linear_rail_state()
-        obs["wheel_speeds"] = self.get_wheel_speeds()
+        obs["wheel_states"] = self.get_wheel_states()
         return obs
 
     def reset_odometry(self) -> Any:
@@ -155,7 +158,7 @@ class Args:
     command: Literal[
         "get_odometry",
         "get_observation",
-        "get_wheel_speeds",
+        "get_wheel_states",
         "reset_odometry",
         "test_command",
         "test_linear_rail",
@@ -184,8 +187,8 @@ if __name__ == "__main__":
         pprint(client.get_observation(), sort_dicts=False, width=100)
         client.close()
         exit()
-    elif args.command == "get_wheel_speeds":
-        pprint(client.get_wheel_speeds(), sort_dicts=False, width=100)
+    elif args.command == "get_wheel_states":
+        pprint(client.get_wheel_states(), sort_dicts=False, width=100)
         client.close()
         exit()
     elif args.command == "reset_odometry":

--- a/i2rt/flow_base/flow_base_controller.py
+++ b/i2rt/flow_base/flow_base_controller.py
@@ -518,12 +518,30 @@ class Vehicle(Robot):
             self.dx = np.zeros(self.num_dofs)
             self.dx_local = np.zeros(self.num_dofs)
 
-    def get_wheel_speeds(self, input_dict: Dict[str, Any] | None = None) -> Dict[str, Any]:
-        with self._lock:
-            return {
-                "steer": np.array(self.dq[0::2]),
-                "drive": np.array(self.dq[1::2]),
-            }
+    def get_wheel_states(self, input_dict: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        """Full per-motor state (pos rad, vel rad/s, eff Nm) for the 8 base motors.
+
+        Reads the unified motor chain once and groups the 4 casters into steer/drive. The
+        linear rail (9th) motor, if present, is excluded here; its state is reported by
+        get_linear_rail_state.
+        """
+        motor_states = self.caster_module_controller.motor_interface.read_states()
+        num_casters = self.caster_module_controller.num_casters
+        steer = {"pos": [], "vel": [], "eff": []}
+        drive = {"pos": [], "vel": [], "eff": []}
+        for idx in range(num_casters):
+            s = motor_states[idx * 2]
+            d = motor_states[idx * 2 + 1]
+            steer["pos"].append(s.pos)
+            steer["vel"].append(s.vel)
+            steer["eff"].append(s.eff)
+            drive["pos"].append(d.pos)
+            drive["vel"].append(d.vel)
+            drive["eff"].append(d.eff)
+        return {
+            "steer": {k: np.array(v) for k, v in steer.items()},
+            "drive": {k: np.array(v) for k, v in drive.items()},
+        }
 
     def set_target_velocity(self, velocity: Any, frame: str = "local") -> None:
         self._enqueue_command(CommandType.VELOCITY, velocity, frame)
@@ -746,8 +764,9 @@ class LinearRailVehicle(Vehicle):
         if self.linear_rail is None:
             return {"error": "Linear rail not available"}
         state = self.linear_rail.get_state()
-        if "motor_state" in state:
-            state = {k: v for k, v in state.items() if k != "motor_state"}
+        motor_state = state.pop("motor_state", None)
+        if motor_state is not None:
+            state["eff"] = motor_state.eff  # rail motor torque (Nm)
         return state
 
     def set_linear_rail_velocity(self, velocity: float) -> None:
@@ -895,7 +914,7 @@ if __name__ == "__main__":
     server.bind("get_odometry", vehicle.get_odometry)
     server.bind("reset_odometry", vehicle.reset_odometry)
     server.bind("set_target_velocity", remote_command.remote_set_target_velocity)
-    server.bind("get_wheel_speeds", vehicle.get_wheel_speeds)
+    server.bind("get_wheel_states", vehicle.get_wheel_states)
 
     # Bind linear rail APIs if vehicle has linear rail
     if hasattr(vehicle, "linear_rail"):


### PR DESCRIPTION
## Summary

Extend the flow_base observation so a client gets full per-motor state — position, velocity, and torque — for all 8 base motors plus the 9th (linear rail) motor when enabled. Previously the observation carried only wheel velocities (no position, no torque) and the linear rail reported no torque, leaving the data schema misaligned with the gello/yam motor-chain nodes. The data was already read every control cycle (`MotorInfo.eff`); this change just stops discarding it. Closes ROB-1511.

## Changes

- `i2rt/flow_base/flow_base_controller.py`: renamed `Vehicle.get_wheel_speeds` → `get_wheel_states` and rewrote it to return full per-motor state (pos/vel/eff) for the 8 base motors via a single cached `read_states()` call, grouped steer/drive; added an `eff` (torque, Nm) field to `LinearRailVehicle.get_linear_rail_state` so the 9th motor's torque is reported; updated `server.bind` to `"get_wheel_states"`.
- `i2rt/flow_base/flow_base_client.py`: renamed `FlowBaseClient.get_wheel_speeds` → `get_wheel_states` (method, RPC call, CLI command, docstring) and switched `get_observation` to the `wheel_states` key, so `get_observation()` now returns pos/vel/torque for all 8/9 motors.
- `i2rt/flow_base/README.md`: documented the new `wheel_states` observation key + `get_wheel_states` output, and added the rail `eff` (torque) field to the `get_linear_rail_state` output example.

## How to Test

### 8-motor base (no linear rail)
- [ ] Start controller: `python -m i2rt.flow_base.flow_base_controller --channel <can_channel>`
- [ ] `python -m i2rt.flow_base.flow_base_client --command get_wheel_states` prints `steer` and `drive`, each with `pos`/`vel`/`eff` arrays of length 4.
- [ ] `python -m i2rt.flow_base.flow_base_client --command get_observation` includes a `wheel_states` key and no `linear_rail` key.
- [ ] Back-drive / load a wheel by hand and confirm the matching `eff` value moves off ~0 (torque is live).

### 9-motor base (with linear rail)
- [ ] Start controller with rail: `python -m i2rt.flow_base.flow_base_controller --channel <can_channel> --linear-rail`
- [ ] `python -m i2rt.flow_base.flow_base_client --command get_linear_rail_state --with-linear-rail` output now includes an `eff` field; push/hold the rail and confirm it changes.
- [ ] `python -m i2rt.flow_base.flow_base_client --command get_observation --with-linear-rail` contains full `wheel_states` (8 motors) + `linear_rail` (9th, incl. `eff`) = all 9 motors' pos/vel/torque.

### Regression
- [ ] `python -m i2rt.flow_base.flow_base_client --command get_odometry` is unchanged.
- [ ] Controller logs no new "Step time … ms" warnings (the extra cached `read_states` in the RPC handlers doesn't disturb the control loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
