### PR TITLE
Fix: Default disable auto recovery on motor loss comm

### DIFF
--- a/i2rt/flow_base/flow_base_controller.py
+++ b/i2rt/flow_base/flow_base_controller.py
@@ -160,6 +160,7 @@ class VehicleMotorController:
             channel=channel,
             motor_chain_name="holonomic_base",
             control_mode=ControlMode.VEL,
+            enable_auto_recovery=False,  # fail-fast on motor error (ROB-1449); base does not self-heal
         )
         return motor_interface
 
@@ -676,6 +677,7 @@ class LinearRailVehicle(Vehicle):
             motor_chain_name="linear_rail_vehicle" if enable_linear_rail else "holonomic_base",
             control_mode=ControlMode.VEL,
             control_freq=control_freq,
+            enable_auto_recovery=False,  # fail-fast on motor error (ROB-1449); base does not self-heal
         )
 
         # Initialize brake GPIO only if linear rail is enabled

--- a/i2rt/motor_drivers/dm_driver.py
+++ b/i2rt/motor_drivers/dm_driver.py
@@ -384,6 +384,7 @@ class DMChainCanInterface(MotorChain):
         use_buffered_reader: bool = False,  # buffered reader is not very stable, the latest encoder fix allows us to use the non-buffered reader
         report_interval: float = REPORT_INTERVAL,
         control_freq: float = CONTROL_FREQ,  # Control loop frequency (Hz), used for the CAN bandwidth check
+        enable_auto_recovery: bool = False,  # if True, try to clean+re-enable errored motors in the control loop instead of failing fast
     ):
         assert not use_buffered_reader, (
             "buffered reader is not very stable, the latest encoder fix allows us to use the non-buffered reader"
@@ -401,6 +402,9 @@ class DMChainCanInterface(MotorChain):
         self.motor_offset = np.array(motor_offset, dtype=float)
         self.motor_direction = np.array(motor_direction)
         self.channel = channel
+        # Read live each control-loop iteration; must be set before _motor_on()/start_thread() since
+        # some callers (e.g. _get_gripper_only_robot) start the thread inside this constructor.
+        self.enable_auto_recovery = enable_auto_recovery
         logging.info(f"Channel: {channel}, Bitrate: {bitrate}")
         if "can" in channel:
             self.motor_interface = DMSingleMotorCanInterface(
@@ -578,29 +582,25 @@ class DMChainCanInterface(MotorChain):
                         try:
                             motor_feedback = self._set_commands(self.commands)
                         except RuntimeError as e:
-                            if "Motor error detected" in str(e):
+                            if self.enable_auto_recovery and "Motor error detected" in str(e):
                                 logging.warning(f"Motor error in control loop, attempting recovery: {e}")
-                                recovered = self._try_recover_motors()
-                                if recovered:
+                                if self._try_recover_motors():
                                     logging.warning("Motor recovery successful, continuing control loop")
                                     continue
-                                else:
-                                    self.running = False
-                                    raise
+                                self.running = False
+                                raise
                             raise
 
                         errors = np.array([motor_feedback[i].error_code != "0x1" for i in range(len(motor_feedback))])
                         if np.any(errors):
-                            logging.warning(f"Motor errors detected in feedback: {errors}")
-                            recovered = self._try_recover_motors(motor_feedback)
-                            if recovered:
-                                logging.warning("Motor recovery successful, continuing control loop")
-                                continue
+                            if self.enable_auto_recovery:
+                                logging.warning(f"Motor errors detected in feedback: {errors}, attempting recovery")
+                                if self._try_recover_motors(motor_feedback):
+                                    logging.warning("Motor recovery successful, continuing control loop")
+                                    continue
                             self.running = False
                             logging.error(f"motor errors: {errors}")
-                            raise Exception(
-                                "motors have unrecoverable errors after recovery attempts, stopping control loop"
-                            )
+                            raise Exception(f"motor errors detected: {errors}, stopping control loop")
 
                     with self.state_lock:
                         self.state = motor_feedback

--- a/i2rt/robots/get_robot.py
+++ b/i2rt/robots/get_robot.py
@@ -62,6 +62,7 @@ def _get_gripper_only_robot(
     channel: str = "can0",
     gripper_type: GripperType = GripperType.LINEAR_4310,
     sim: bool = False,
+    enable_auto_recovery: bool = False,
 ) -> "Robot":
     """Create a gripper-only robot (no arm).
 
@@ -69,6 +70,8 @@ def _get_gripper_only_robot(
         channel: CAN interface name (e.g. "can0"). Ignored in sim mode.
         gripper_type: Which gripper to load. Must not be NO_GRIPPER.
         sim: If True, return a SimRobot instead of connecting to real hardware.
+        enable_auto_recovery: If True, the motor chain tries to clean+re-enable errored motors in its
+            control loop instead of failing fast. Defaults to False (fail-fast).
     """
     if gripper_type == GripperType.NO_GRIPPER:
         raise ValueError("gripper_type cannot be NO_GRIPPER when arm_type is NO_ARM")
@@ -108,6 +111,7 @@ def _get_gripper_only_robot(
         motor_chain_name="gripper_only",
         receive_mode=ReceiveMode.p16,
         start_thread=True,
+        enable_auto_recovery=enable_auto_recovery,
     )
 
     return MotorChainRobot(
@@ -140,6 +144,7 @@ def get_yam_robot(
     sim: bool = False,
     joint_state_saver_factory: Optional[Callable[[], Any]] = None,
     set_realtime_and_pin_callback: Optional[Callable[[int], None]] = None,
+    enable_auto_recovery: bool = False,
 ) -> "Robot":
     """Create a YAM-family robot (real or sim).
 
@@ -156,10 +161,14 @@ def get_yam_robot(
         gripper_kp: Optional gripper kp override. Defaults to gripper_type's default.
         gripper_kd: Optional gripper kd override. Defaults to gripper_type's default.
         sim: If True, return a SimRobot instead of connecting to real hardware.
+        enable_auto_recovery: If True, the motor chain tries to clean+re-enable errored motors in its
+            control loop instead of failing fast. Defaults to False (fail-fast).
     """
     # --- Gripper-only path (no arm) -------------------------------------------
     if arm_type == ArmType.NO_ARM:
-        return _get_gripper_only_robot(channel=channel, gripper_type=gripper_type, sim=sim)
+        return _get_gripper_only_robot(
+            channel=channel, gripper_type=gripper_type, sim=sim, enable_auto_recovery=enable_auto_recovery
+        )
 
     with_gripper = gripper_type not in (GripperType.YAM_TEACHING_HANDLE, GripperType.NO_GRIPPER)
     with_teaching_handle = gripper_type == GripperType.YAM_TEACHING_HANDLE
@@ -245,6 +254,7 @@ def get_yam_robot(
         start_thread=False,
         get_same_bus_device_driver=get_encoder_chain if with_teaching_handle else None,
         use_buffered_reader=False,
+        enable_auto_recovery=enable_auto_recovery,
     )
     motor_states = motor_chain.read_states()
     logging.debug(f"motor_states: {motor_states}")

--- a/i2rt/robots/motor_chain_robot.py
+++ b/i2rt/robots/motor_chain_robot.py
@@ -93,6 +93,7 @@ class MotorChainRobot(Robot):
         pinned_cpu: int | None = None,
         joint_state_saver_factory: Optional[Callable[[], Any]] = None,
         set_realtime_and_pin_callback: Optional[Callable[[int], None]] = None,
+        enable_auto_recovery: Optional[bool] = None,  # None: inherit motor_chain's setting; True/False: override it
     ) -> None:
         # Set up CPU pinning and real-time scheduling if requested
         if pinned_cpu is not None and set_realtime_and_pin_callback is not None:
@@ -138,6 +139,10 @@ class MotorChainRobot(Robot):
         assert clip_motor_torque >= 0.0
         self._clip_motor_torque = clip_motor_torque
         self.motor_chain = motor_chain
+        # None means inherit whatever the chain was constructed with; an explicit value overrides it.
+        # The chain reads this flag live each control-loop iteration, so a late set is safe.
+        if enable_auto_recovery is not None:
+            self.motor_chain.enable_auto_recovery = enable_auto_recovery
         self.use_gravity_comp = use_gravity_comp
         self.gravity_comp_factor = (
             gravity_comp_factor if gravity_comp_factor is not None else np.ones(len(motor_chain))
@@ -303,6 +308,7 @@ class MotorChainRobot(Robot):
             "gripper_limits": self._gripper_limits,
             "gravity_comp_factor": self.gravity_comp_factor,
             "gripper_index": self._gripper_index,
+            "enable_auto_recovery": getattr(self.motor_chain, "enable_auto_recovery", False),
         }
         if self._gripper_index is not None:
             info["limit_gripper_effort"] = self._limit_gripper_force


### PR DESCRIPTION
## Summary

Motor auto-recovery in the DM control loop is now **opt-in and disabled by default**, so a loss-communication (`0xD`) or other motor error now fails fast — the control loop sets `running=False` and re-raises — instead of silently clearing the error and re-enabling the motor. This prevents the dangerous behavior tracked in ROB-1449, where a YAM arm auto-recovered after a `loss communication` and swung violently on re-enable, posing a safety risk to nearby people. Callers that still want the old self-healing behavior can opt back in with `enable_auto_recovery=True`.

Because the default flips at the `DMChainCanInterface` constructor, this fail-fast behavior also applies to the **mobile base**: the holonomic base (wheel/steer motors) and the linear-rail lift motor now stop the control loop and raise on a motor error instead of self-healing. This is intentional for safety consistency with the YAM arm, and `i2rt/flow_base/flow_base_controller.py` now passes `enable_auto_recovery=False` explicitly at both motor-chain constructions so the intent is clear at the call site.

## Changes

- `i2rt/motor_drivers/dm_driver.py`: added an `enable_auto_recovery` constructor flag (default `False`, read live each control-loop iteration so a late override is safe) and gated both recovery paths behind it — the `RuntimeError("Motor error detected")` catch and the per-motor `error_code` feedback check. With the flag off, any motor error stops the loop and propagates instead of being cleared.
- `i2rt/robots/get_robot.py`: threaded `enable_auto_recovery` (default `False`) through `get_yam_robot` and `_get_gripper_only_robot` into the `DMChainCanInterface` constructor, with docstring notes.
- `i2rt/robots/motor_chain_robot.py`: added an `enable_auto_recovery` override on `MotorChainRobot` (`None` = inherit the chain's setting; explicit `True`/`False` overrides it) and exposed the effective value in the robot `info` dict.
- `i2rt/flow_base/flow_base_controller.py`: explicitly pass `enable_auto_recovery=False` at the `holonomic_base` (`VehicleMotorController._initialize_motor_chain`) and `unified_motor_chain` (`LinearRailVehicle.__init__`) `DMChainCanInterface` constructions, documenting that the mobile base also fails fast on motor error. Functional no-op — the constructor default is already `False`.

## Test Plan

- [ ] `python -m py_compile i2rt/motor_drivers/dm_driver.py i2rt/robots/get_robot.py i2rt/robots/motor_chain_robot.py` passes.
- [ ] Default is fail-fast: build a robot with `get_yam_robot(channel="can0")` and confirm `robot.get_info()["enable_auto_recovery"] is False` (or inspect `robot.motor_chain.enable_auto_recovery`).
- [ ] On real hardware (YAM arm), induce a motor `loss communication` (e.g. unplug a motor or trigger over-temp on motor id 1) during a control loop and confirm the loop **stops and raises** rather than clearing the error and re-enabling — i.e. no violent re-swing (reproduces & fixes ROB-1449).
- [ ] Opt-in still works: construct with `get_yam_robot(channel="can0", enable_auto_recovery=True)`, induce the same fault, and confirm the loop logs `attempting recovery` and continues when recovery succeeds.
- [ ] Late override: `MotorChainRobot(..., enable_auto_recovery=True)` flips a chain built with the default — confirm `motor_chain.enable_auto_recovery is True` after construction.
- [ ] On real hardware (mobile base), induce a base motor `loss communication` (e.g. unplug a wheel/steer motor, or the linear-rail motor) mid-drive and confirm the base control loop **stops and raises** instead of self-healing.

Closes ROB-1449

🤖 Generated with [Claude Code](https://claude.com/claude-code)
