### PR TITLE
[1.2.2-hotfix] fix(flow_base): integrate odometry against measured loop dt

### DIFF
--- a/i2rt/flow_base/flow_base_controller.py
+++ b/i2rt/flow_base/flow_base_controller.py
@@ -311,7 +311,28 @@ class Vehicle(Robot):
         if auto_start:
             self.start_control()
 
-    def update_state(self) -> None:
+    @staticmethod
+    def _integrate_pose(x: np.ndarray, dx_local: np.ndarray, dt: float) -> Tuple[np.ndarray, np.ndarray]:
+        """Midpoint-Euler integrate world pose x by body twist dx_local over dt.
+
+        Returns (new_x, dx_world). Uses the half-step heading so the body twist is rotated
+        into the world frame at the midpoint of the interval.
+        """
+        theta_avg = x[2] + 0.5 * dx_local[2] * dt
+        R = np.array(
+            [
+                [math.cos(theta_avg), -math.sin(theta_avg), 0.0],
+                [math.sin(theta_avg), math.cos(theta_avg), 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        dx = R @ dx_local
+        return x + dx * dt, dx
+
+    def update_state(self, dt: float | None = None) -> None:
+        # Integrate against the actual elapsed loop time; fall back to the nominal period.
+        if dt is None:
+            dt = self.control_period
         # Joint positions and velocities
         now = time.time()
         state_dict = self.caster_module_controller.get_state()
@@ -357,16 +378,7 @@ class Vehicle(Robot):
         with self._lock:
             dx_local = AXIS_SIGN * (self.C_pinv @ self.dq)
             self.dx_local = dx_local
-            theta_avg = self.x[2] + 0.5 * dx_local[2] * self.control_period
-            R = np.array(
-                [
-                    [math.cos(theta_avg), -math.sin(theta_avg), 0.0],
-                    [math.sin(theta_avg), math.cos(theta_avg), 0.0],
-                    [0.0, 0.0, 1.0],
-                ]
-            )
-            self.dx = R @ dx_local
-            self.x += self.dx * self.control_period
+            self.x, self.dx = self._integrate_pose(self.x, dx_local, dt)
         time.sleep(0.0005)
 
     def start_control(self) -> None:
@@ -407,8 +419,8 @@ class Vehicle(Robot):
             if step_time > 0.01:  # 10 ms
                 logger.warning(f"Step time {1000 * step_time:.3f} ms in {self.__class__.__name__} control_loop")
 
-            # Update state
-            self.update_state()
+            # Update state (integrate odometry against the measured loop period)
+            self.update_state(step_time)
             # Global to local frame conversion
             theta = self.x[2]
             R = np.array(

--- a/i2rt/flow_base/tests/test_odometry_integration.py
+++ b/i2rt/flow_base/tests/test_odometry_integration.py
@@ -1,0 +1,77 @@
+"""Unit tests for the base odometry pose integrator (Vehicle._integrate_pose).
+
+These exercise the pure integration math with no hardware: the regression guard is that
+displacement scales with the *actual* elapsed dt, which the previous fixed-nominal-period
+integration could not express (it always advanced by control_period regardless of dt).
+"""
+
+import math
+
+import numpy as np
+
+from i2rt.flow_base.flow_base_controller import Vehicle
+
+
+def test_pose_integration_scales_with_dt() -> None:
+    # Regression guard: same twist, twice the dt -> twice the displacement.
+    # The old fixed-dt integrator would have produced identical displacement for both.
+    x0 = np.zeros(3)
+    twist = np.array([1.0, 0.0, 0.0])  # 1 m/s forward, no rotation
+
+    x_t, _ = Vehicle._integrate_pose(x0, twist, 0.005)
+    x_2t, _ = Vehicle._integrate_pose(x0, twist, 0.010)
+
+    np.testing.assert_allclose(x_t, [0.005, 0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(x_2t, [0.010, 0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(x_2t[0], 2.0 * x_t[0], atol=1e-12)
+
+
+def test_straight_line_uses_measured_dt() -> None:
+    # A slow loop (8 ms) must integrate the full 8 ms of motion, not the nominal 5 ms.
+    x0 = np.zeros(3)
+    twist = np.array([1.0, 0.0, 0.0])
+
+    x_new, dx_world = Vehicle._integrate_pose(x0, twist, 0.008)
+
+    np.testing.assert_allclose(x_new, [0.008, 0.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(dx_world, twist, atol=1e-12)  # heading 0 -> world == body
+
+
+def test_forward_motion_respects_starting_heading() -> None:
+    # Forward body twist from a non-zero heading translates along that heading.
+    theta0 = math.pi / 3
+    dt = 0.008
+    x0 = np.array([0.0, 0.0, theta0])
+    twist = np.array([1.0, 0.0, 0.0])
+
+    x_new, _ = Vehicle._integrate_pose(x0, twist, dt)
+
+    expected = np.array([math.cos(theta0) * dt, math.sin(theta0) * dt, theta0])
+    np.testing.assert_allclose(x_new, expected, atol=1e-12)
+
+
+def test_pure_rotation_advances_heading() -> None:
+    omega = 2.0  # rad/s
+    dt = 0.008
+    x0 = np.zeros(3)
+    twist = np.array([0.0, 0.0, omega])
+
+    x_new, _ = Vehicle._integrate_pose(x0, twist, dt)
+
+    # Pure spin: heading advances by omega*dt, no translation.
+    np.testing.assert_allclose(x_new, [0.0, 0.0, omega * dt], atol=1e-12)
+
+
+def test_midpoint_heading_is_scaled_by_dt() -> None:
+    # Combined forward + angular twist: translation is rotated by the *midpoint* heading
+    # (0.5 * omega * dt), so its direction must depend on the measured dt.
+    omega = 2.0
+    dt = 0.008
+    x0 = np.zeros(3)
+    twist = np.array([1.0, 0.0, omega])
+
+    x_new, _ = Vehicle._integrate_pose(x0, twist, dt)
+
+    heading_of_translation = math.atan2(x_new[1], x_new[0])
+    np.testing.assert_allclose(heading_of_translation, 0.5 * omega * dt, atol=1e-12)
+    np.testing.assert_allclose(x_new[2], omega * dt, atol=1e-12)


### PR DESCRIPTION
## Summary

`Vehicle.update_state()` integrated the base pose by multiplying the (correct, instantaneous) twist by the **fixed nominal** timestep `self.control_period` (`1/control_freq`, default `1/200 s`) instead of the **actual elapsed loop time**. The control loop already measures the real per-iteration time as `step_time` but used it only for a `>10 ms` warning log. Because the loop's busy-wait enforces `step_time >= control_period` as a floor, whenever the loop can't hold its nominal rate (e.g. ~124 Hz / ~8 ms under station load) pose **under-integrates** by roughly `control_period / step_time` (~0.63×), systematically shrinking the trajectory. This PR integrates pose against the measured loop `dt`, fixing the root cause so the `position` channel is trustworthy for all consumers. The control/OTG/motor-command path is unchanged.

## Changes

- `i2rt/flow_base/flow_base_controller.py`: extracted the pose integrator into the pure static helper `Vehicle._integrate_pose(x, dx_local, dt)` (behavior-preserving refactor of the old `theta_avg`/`R`/`self.x +=` block); `update_state(self, dt=None)` now integrates over the passed-in `dt` (falling back to `self.control_period`); the control loop passes the already-measured `step_time` at the call site. `Ruckig` OTG cycle time and the loop-rate busy-wait intentionally remain on `control_period`.
- `i2rt/flow_base/tests/test_odometry_integration.py`: new hardware-free regression tests for `_integrate_pose` — dt-proportionality (same twist, 2× dt → 2× displacement; the property the old fixed-dt code could not express), straight-line, non-zero starting heading, pure-rotation, and midpoint-heading-scaled-by-dt.

## Test Plan

- [ ] `uv run pytest i2rt/flow_base/tests/test_odometry_integration.py -q` — expect 5 passed.
- [ ] `uv run pytest i2rt/robots/tests -q` — expect no regressions (260 passed, 2 skipped locally).
- [ ] `uv run ruff check i2rt/flow_base/flow_base_controller.py i2rt/flow_base/tests/test_odometry_integration.py && uv run ruff format --check i2rt/flow_base/flow_base_controller.py i2rt/flow_base/tests/test_odometry_integration.py` — clean.
- [ ] Confirm `self.control_period` is referenced only at the definition, the `Ruckig(...)` OTG construction, the `update_state` default guard, and the busy-wait floor — not at the odometry integration sites: `git grep -n "self.control_period" i2rt/flow_base/flow_base_controller.py`.
- [ ] Bench check on hardware: start `python -m i2rt.flow_base.flow_base_controller --channel <can>`, `reset_odometry()`, command a constant forward velocity for a fixed wall-clock duration, then compare the `get_odometry()` position delta to `commanded_vel × duration`. Force the buggy regime with a high `--control_freq` (e.g. 400 Hz) so the loop cannot keep up and real `step_time` >> `control_period`; integrated distance should now match commanded regardless of loop rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
