### PR TITLE
chore(deps): upgrade tyro to >=1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "rerun-sdk>=0.32.2",
     "ruckig==0.15.3",
     "threadpoolctl==3.6.0",
-    "tyro==0.9.26",
+    "tyro>=1.0.0",
     "viser>=0.2.0",
     # USB-to-GPIO converter for the linear-rail brake + limit switches on x86/non-Pi hosts.
     "pyserial>=3.5",


### PR DESCRIPTION
## Summary

Upgrade the `tyro` CLI-parsing dependency from a hard pin at `0.9.26` to `>=1.0.0`, moving the project onto the stable 1.0 line (locally resolves/verified against 1.0.15).

## Changes

- pyproject.toml: bumped `tyro==0.9.26` → `tyro>=1.0.0`. All 5 usages in the repo are plain `tyro.cli(Args)` calls on dataclasses whose fields are limited to `str` / `bool` / `int` / `float` / `Optional` / `str | None` / `Literal[...]`, all of which parse identically under tyro 1.0. (`uv.lock` is gitignored, so it is not part of this diff; it was regenerated locally to install and verify 1.0.15.)

## Test Plan

- [ ] `uv sync` and confirm `python -c "import tyro; print(tyro.__version__)"` reports `>=1.0.0`.
- [ ] Confirm each CLI still builds its parser and prints help without error:
    - [ ] `python i2rt/flow_base/flow_base_client.py --help`
    - [ ] `python i2rt/flow_base/flow_base_controller.py --help`
    - [ ] `python examples/plot_flow_base_rerun/plot_flow_base_rerun.py --help`
    - [ ] `python examples/drive_flow_base_viser/drive_flow_base_viser.py --help`
    - [ ] `python examples/minimum_gello/minimum_gello.py --help`
- [ ] Spot-check argument coercion, e.g. `python examples/minimum_gello/minimum_gello.py --arm yam_pro --sim` parses `arm='yam_pro'`, `sim=True`.
- [ ] Edge case: pass an invalid `Literal` value (e.g. `--arm bogus`) and confirm tyro rejects it with a nonzero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)