### PR TITLE
[1.2.2-hotfix]

### DIFF
--- a/i2rt/robot_models/arm/yam_ultra/yam_ultra.urdf
+++ b/i2rt/robot_models/arm/yam_ultra/yam_ultra.urdf
@@ -129,7 +129,7 @@
             </material>
         </visual>
     </link>
-    <link name="ultra_base">
+    <link name="base">
         <inertial>
             <mass value="0.940115" />
             <origin xyz="-0.0274792 -2.26344e-05 3.611e-05" rpy="0 -0 0" />
@@ -138,7 +138,7 @@
         <visual>
             <origin xyz="-0.193801 -0.0464005 -0.0374966" rpy="0 -0 0" />
             <geometry>
-                <mesh filename="package://urdf_top_assembly/meshes/ultra_base.stl" scale="1 1 1" />
+                <mesh filename="package://urdf_top_assembly/meshes/base.stl" scale="1 1 1" />
             </geometry>
             <material name="0.317647_0.121569_0.498039_0.000000_0.000000">
                 <color rgba="0.317647 0.121569 0.498039 1" />
@@ -149,13 +149,13 @@
         <origin xyz="-4.16334e-17 0 0" rpy="0 1.5708 -3.57884e-17" />
         <axis xyz="-1 0 0" />
         <parent link="root" />
-        <child link="ultra_base" />
+        <child link="base" />
         <limit effort="1" velocity="1" lower="0" upper="0" />
     </joint>
     <joint name="dof_joint1" type="revolute">
         <origin xyz="-0.0733 -1.27793e-15 -8.20164e-16" rpy="1.6619e-16 -2.22045e-16 3.93401e-17" />
         <axis xyz="-1 0 0" />
-        <parent link="ultra_base" />
+        <parent link="base" />
         <child link="link1" />
         <limit effort="1" velocity="1" lower="-2.61799" upper="3.05433" />
     </joint>


### PR DESCRIPTION
## Summary

The `yam_ultra.urdf` referenced a link named `ultra_base` and a mesh `ultra_base.stl`, but the only base mesh in the tree is `assets/base.stl` (there is no `ultra_base.stl`) — so the mesh reference was dangling. This renames the link and mesh to `base` so the URDF points at the asset that actually exists.

## Changes

- `i2rt/robot_models/arm/yam_ultra/yam_ultra.urdf`: renamed link `ultra_base` → `base`, updated the mesh filename `ultra_base.stl` → `base.stl`, and updated the `parent`/`child` link references on the fixed joint and `dof_joint1` to match.

## Test Plan

- [ ] Confirm the referenced mesh exists: `ls i2rt/robot_models/arm/yam_ultra/assets/base.stl` (should be present; `ultra_base.stl` should not exist).
- [ ] Confirm the URDF no longer references the old name: `grep -c ultra_base i2rt/robot_models/arm/yam_ultra/yam_ultra.urdf` returns `0`.
- [ ] Load the URDF in a viewer (e.g. `python -c "import yourdfpy; yourdfpy.URDF.load('i2rt/robot_models/arm/yam_ultra/yam_ultra.urdf')"` or your usual sim/visualizer) and confirm the `base` link renders with its mesh and the kinematic chain (`root` → `base` → `link1`) is intact.

Closes ROB-1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)