### PR TITLE
docs(readme): add top-level pointer to doc.i2rt.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Python client library for interacting with [I2RT](https://i2rt.com/) products 
 
 [![I2RT](https://github.com/user-attachments/assets/025ac3f0-7af1-4e6f-ab9f-7658c5978f92)](https://i2rt.com/)
 
+> 📚 **Full documentation:** [doc.i2rt.com](https://doc.i2rt.com)
+
 ## Features
 
 - Plug-and-play Python interface for YAM arms and Flow Base


### PR DESCRIPTION
## Summary

Adds a single one-line pointer near the top of the README that points to [doc.i2rt.com](https://doc.i2rt.com).

## Why

After #48 synced README from JH_i2rt, the repo lost all links to the hosted docs site. This adds back the minimum — just a top-level pointer — so users landing on the GitHub repo can find the full docs at doc.i2rt.com without having to know the URL.

Kept intentionally minimal (one line) so it survives future JH_i2rt syncs without producing merge conflicts in individual sections.

## Diff

```diff
 [![I2RT](https://github.com/user-attachments/assets/025ac3f0-7af1-4e6f-ab9f-7658c5978f92)](https://i2rt.com/)

+> 📚 **Full documentation:** [doc.i2rt.com](https://doc.i2rt.com)
+
 ## Features
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)