### PR TITLE
fix(models): correct YAM joint limits to measured values (Std/Pro/Ultra)

### DIFF
--- a/i2rt/robot_models/arm/yam/yam.urdf
+++ b/i2rt/robot_models/arm/yam/yam.urdf
@@ -157,14 +157,14 @@
         <axis xyz="-1 0 0" />
         <parent link="base" />
         <child link="link1" />
-        <limit effort="1" velocity="1" lower="-2.61799" upper="3.05433" />
+        <limit effort="1" velocity="1" lower="-2.61799" upper="3.14159" />
     </joint>
     <joint name="dof_joint2" type="revolute">
         <origin xyz="-0.0455 -0.0339 -0.02" rpy="4.86604e-16 3.99049e-14 -3.14159" />
         <axis xyz="3.58252e-15 1 -3.2007e-16" />
         <parent link="link1" />
         <child link="link2" />
-        <limit effort="1" velocity="1" lower="-3.9968e-14" upper="3.14159" />
+        <limit effort="1" velocity="1" lower="0" upper="3.66519" />
     </joint>
     <joint name="dof_joint3" type="revolute">
         <origin xyz="4.08431e-07 -0.0688 0.264" rpy="-1.01074e-14 7.11653e-14 -3.14159" />
@@ -178,7 +178,7 @@
         <axis xyz="0 1 0" />
         <parent link="link3" />
         <child link="link4" />
-        <limit effort="1" velocity="1" lower="-1.5708" upper="1.5708" />
+        <limit effort="1" velocity="1" lower="-1.69297" upper="1.5708" />
     </joint>
     <joint name="dof_joint5" type="revolute">
         <origin xyz="-0.0405003 0.0338995 -0.0739989" rpy="-2.58127e-15 -1.37665e-15 -1.04686e-15" />

--- a/i2rt/robot_models/arm/yam/yam.xml
+++ b/i2rt/robot_models/arm/yam/yam.xml
@@ -14,19 +14,19 @@
     <geom pos="-0.0374966 -0.0464005 0.187501" quat="0.707105 0 0.707108 0" type="mesh" rgba="0.317647 0.121569 0.498039 1" mesh="base"/>
     <body name="link1" pos="0 0 0.067" quat="0.707105 0 0 -0.707108">
       <inertial pos="-0.00172503 0.00727828 0.0233636" quat="0.606194 0.360814 0.639149 0.306319" mass="0.101218" diaginertia="0.000134913 0.000106251 4.71815e-05"/>
-      <joint name="joint1" pos="0 0 0" axis="0 0 1" range="-2.61799 3.05433" actuatorfrcrange="-10 10"/>
+      <joint name="joint1" pos="0 0 0" axis="0 0 1" range="-2.61799 3.14159" actuatorfrcrange="-10 10"/>
       <geom pos="-0.0464 0.0374968 0.119501" quat="0.499998 0.5 0.5 -0.500002" type="mesh" rgba="0.72549 0.45098 0.317647 1" mesh="link1"/>
       <body name="link2" pos="-0.0329 0.02 0.0455" quat="0.499998 0.5 -0.500002 -0.5">
         <inertial pos="0.129165 0.000134495 -0.0321253" quat="0.499976 0.500008 0.500105 0.499911" mass="1.46908" diaginertia="0.0146686 0.014599 0.000800089"/>
-        <joint name="joint2" pos="0 0 0" axis="0 0 1" range="0 3.65" actuatorfrcrange="-10 10"/>
+        <joint name="joint2" pos="0 0 0" axis="0 0 1" range="0 3.66519" actuatorfrcrange="-10 10"/>
         <geom pos="-0.0174977 -0.0740001 -0.07925" quat="0.499998 0.5 0.500002 0.5" type="mesh" rgba="0 0.4 0.6 1" mesh="link2"/>
         <body name="link3" pos="0.264 4.08431e-07 -0.06375" quat="9.38184e-07 -0.707105 -0.707108 9.38187e-07">
           <inertial pos="0.0556042 -0.135083 -0.0340514" quat="0.704407 0.697077 0.121918 -0.0550519" mass="0.982553" diaginertia="0.00765198 0.0076296 0.000876442"/>
-          <joint name="joint3" pos="0 0 0" axis="0 0 1" range="0 3.66519" actuatorfrcrange="-10 10"/>
+          <joint name="joint3" pos="0 0 0" axis="0 0 1" range="0 3.14159" actuatorfrcrange="-10 10"/>
           <geom pos="0.0740003 -0.281499 -0.0813" quat="9.38184e-07 9.38187e-07 -0.707108 -0.707105" type="mesh" rgba="0.552941 0.580392 0.203922 1" mesh="link3"/>
           <body name="link4" pos="0.0600003 -0.244999 -0.00205" quat="1.32679e-06 0 0 -1">
             <inertial pos="-0.0550959 0.0575534 -0.032726" quat="0.616542 0.637394 0.223937 0.404299" mass="0.462165" diaginertia="0.00078789 0.00076643 0.00028779"/>
-            <joint name="joint4" pos="0 0 0" axis="0 0 1" range="-1.5708 1.5708" actuatorfrcrange="-10 10"/>
+            <joint name="joint4" pos="0 0 0" axis="0 0 1" range="-1.69297 1.5708" actuatorfrcrange="-10 10"/>
             <geom pos="-0.0138003 0.0364989 -0.0787882" quat="0.707105 0.707108 0 0" type="mesh" rgba="0.545098 0.52549 0.419608 1" mesh="link4"/>
             <body name="link5" pos="-0.0403003 0.0703851 -0.0323887" quat="9.38184e-07 -0.707105 -9.38187e-07 -0.707108">
               <inertial pos="-3.55003e-05 -0.00717397 0.0375847" quat="0.911516 0.411243 -0.00302177 -0.00303654" mass="0.403307" diaginertia="0.000219794 0.000195686 0.000169647"/>

--- a/i2rt/robot_models/arm/yam_pro/yam_pro.urdf
+++ b/i2rt/robot_models/arm/yam_pro/yam_pro.urdf
@@ -333,28 +333,28 @@
         <axis xyz="-1 0 0" />
         <parent link="base_1" />
         <child link="link1" />
-        <limit effort="1" velocity="1" lower="-2.61799" upper="3.05433" />
+        <limit effort="1" velocity="1" lower="-2.61799" upper="3.14159" />
     </joint>
     <joint name="dof_joint2" type="revolute">
         <origin xyz="-0.0455 -0.0329 -0.02" rpy="4.47367e-16 5.42424e-16 4.00074e-15" />
         <axis xyz="-3.58252e-15 -1 3.35753e-16" />
         <parent link="link1" />
         <child link="link2_1" />
-        <limit effort="1" velocity="1" lower="0" upper="3.14159" />
+        <limit effort="1" velocity="1" lower="0" upper="3.66519" />
     </joint>
     <joint name="dof_joint3" type="revolute">
         <origin xyz="4.08431e-07 -0.00205 0.264" rpy="-1.08814e-14 5.62765e-16 6.86704e-16" />
         <axis xyz="4.54273e-15 1 1.04275e-14" />
         <parent link="link2_1" />
         <child link="link3" />
-        <limit effort="1" velocity="1" lower="-6.28319" upper="3.66519" />
+        <limit effort="1" velocity="1" lower="0" upper="3.14159" />
     </joint>
     <joint name="dof_joint4" type="revolute">
         <origin xyz="-0.0600003 0.0688 -0.244999" rpy="1.04275e-14 3.83027e-15 -4.34003e-15" />
         <axis xyz="0 1 0" />
         <parent link="link3" />
         <child link="link4_1" />
-        <limit effort="1" velocity="1" lower="-1.5708" upper="1.5708" />
+        <limit effort="1" velocity="1" lower="-1.69297" upper="1.5708" />
     </joint>
     <joint name="dof_joint5" type="revolute">
         <origin xyz="-0.0403003 -0.0338507 -0.0739989" rpy="-1.03641e-14 -1.15907e-14 6.37337e-29" />

--- a/i2rt/robot_models/arm/yam_pro/yam_pro.xml
+++ b/i2rt/robot_models/arm/yam_pro/yam_pro.xml
@@ -14,19 +14,19 @@
     <geom pos="-0.0374966 -0.0464005 0.187501" quat="0.707105 0 0.707108 0" type="mesh" rgba="0.317647 0.121569 0.498039 1" mesh="base"/>
     <body name="link1" pos="0 0 0.067" quat="0.707105 0 0 -0.707108">
       <inertial pos="-0.00261782 0.00744082 0.0237251" quat="0.602276 0.365837 0.642523 0.300984" mass="0.104154" diaginertia="0.000139023 0.000109628 4.8478e-05"/>
-      <joint name="joint1" pos="0 0 0" axis="0 0 1" range="-2.61799 3.05433" actuatorfrcrange="-10 10"/>
+      <joint name="joint1" pos="0 0 0" axis="0 0 1" range="-2.61799 3.14159" actuatorfrcrange="-10 10"/>
       <geom pos="-0.0464 0.0374968 0.119501" quat="0.499998 0.5 0.5 -0.500002" type="mesh" rgba="0.72549 0.45098 0.317647 1" mesh="link1"/>
       <body name="link2" pos="-0.0329 0.02 0.0455" quat="0.499998 0.5 -0.500002 -0.5">
         <inertial pos="0.129165 0.000134495 -0.0321253" quat="0.499976 0.500008 0.500105 0.499911" mass="1.52608" diaginertia="0.0152377 0.0151654 0.000831129"/>
-        <joint name="joint2" pos="0 0 0" axis="0 0 1" range="0 3.14159" actuatorfrcrange="-10 10"/>
+        <joint name="joint2" pos="0 0 0" axis="0 0 1" range="0 3.66519" actuatorfrcrange="-10 10"/>
         <geom pos="-0.0174977 -0.0740001 -0.07925" quat="0.499998 0.5 0.500002 0.5" type="mesh" rgba="0 0.4 0.6 1" mesh="link2"/>
         <body name="link3" pos="0.264 4.08431e-07 -0.06375" quat="9.38184e-07 -0.707105 -0.707108 9.38187e-07">
           <inertial pos="0.0556042 -0.135083 -0.0340514" quat="0.704407 0.697077 0.121918 -0.0550519" mass="0.982553" diaginertia="0.00765198 0.0076296 0.000876442"/>
-          <joint name="joint3" pos="0 0 0" axis="0 0 1" range="0 3.66519" actuatorfrcrange="-10 10"/>
+          <joint name="joint3" pos="0 0 0" axis="0 0 1" range="0 3.14159" actuatorfrcrange="-10 10"/>
           <geom pos="0.0740003 -0.281499 -0.0813" quat="9.38184e-07 9.38187e-07 0.707108 0.707105" type="mesh" rgba="0.552941 0.580392 0.203922 1" mesh="link3"/>
           <body name="link4" pos="0.0600003 -0.244999 -0.00205" quat="1.32679e-06 0 0 -1">
             <inertial pos="-0.0543529 0.057068 -0.0332231" quat="0.636075 0.627088 0.370444 0.254833" mass="0.46678" diaginertia="0.000817855 0.000791274 0.000295776"/>
-            <joint name="joint4" pos="0 0 0" axis="0 0 1" range="-1.5708 1.5708" actuatorfrcrange="-10 10"/>
+            <joint name="joint4" pos="0 0 0" axis="0 0 1" range="-1.69297 1.5708" actuatorfrcrange="-10 10"/>
             <geom pos="-0.0138003 0.0364989 -0.0787882" quat="0.707105 0.707108 0 0" type="mesh" rgba="0.545098 0.52549 0.419608 1" mesh="link4"/>
             <body name="link5" pos="-0.0403003 0.0703851 -0.0323887" quat="9.38184e-07 -0.707105 -9.38187e-07 -0.707108">
               <inertial pos="-3.55003e-05 -0.00717397 0.0375847" quat="0.911516 0.411243 -0.00302177 -0.00303654" mass="0.403307" diaginertia="0.000219794 0.000195686 0.000169647"/>

--- a/i2rt/robot_models/arm/yam_ultra/yam_ultra.urdf
+++ b/i2rt/robot_models/arm/yam_ultra/yam_ultra.urdf
@@ -157,28 +157,28 @@
         <axis xyz="-1 0 0" />
         <parent link="base" />
         <child link="link1" />
-        <limit effort="1" velocity="1" lower="-2.61799" upper="3.05433" />
+        <limit effort="1" velocity="1" lower="-2.61799" upper="3.14159" />
     </joint>
     <joint name="dof_joint2" type="revolute">
         <origin xyz="-0.0455 0.03285 -0.02" rpy="-6.12812e-16 1.38778e-16 4.61357e-15" />
         <axis xyz="3.58252e-15 1 -3.2007e-16" />
         <parent link="link1" />
         <child link="link2" />
-        <limit effort="1" velocity="1" lower="-3.14159" upper="3.55271e-15" />
+        <limit effort="1" velocity="1" lower="0" upper="3.66519" />
     </joint>
     <joint name="dof_joint3" type="revolute">
         <origin xyz="4.08431e-07 -0.0678 0.264" rpy="-9.81467e-15 6.80289e-14 -9.61378e-18" />
         <axis xyz="4.54273e-15 1 1.04275e-14" />
         <parent link="link2" />
         <child link="link3" />
-        <limit effort="1" velocity="1" lower="0" upper="3.66519" />
+        <limit effort="1" velocity="1" lower="0" upper="3.14159" />
     </joint>
     <joint name="dof_joint4" type="revolute">
         <origin xyz="-0.0600003 0.0678 -0.244999" rpy="4.17957e-15 -6.65093e-14 -6.51788e-15" />
         <axis xyz="0 1 0" />
         <parent link="link3" />
         <child link="link4" />
-        <limit effort="1" velocity="1" lower="-1.5708" upper="1.5708" />
+        <limit effort="1" velocity="1" lower="-1.69297" upper="1.5708" />
     </joint>
     <joint name="dof_joint5" type="revolute">
         <origin xyz="-0.0403003 -0.0338507 -0.0703851" rpy="-3.44701e-15 -5.07057e-15 -5.25136e-15" />

--- a/i2rt/robot_models/arm/yam_ultra/yam_ultra.xml
+++ b/i2rt/robot_models/arm/yam_ultra/yam_ultra.xml
@@ -14,19 +14,19 @@
     <geom pos="-0.0374966 -0.0464005 0.193801" quat="0.707105 0 0.707108 0" type="mesh" rgba="0.317647 0.121569 0.498039 1" mesh="base"/>
     <body name="link1" pos="0 0 0.0733" quat="1 0 0 0">
       <inertial pos="0.00744082 0.00261782 0.0237251" quat="0.638701 0.713018 0.195647 -0.213045" mass="0.104154" diaginertia="0.000139023 0.000109628 4.8478e-05"/>
-      <joint name="joint1" pos="0 0 0" axis="0 0 1" range="-2.61799 3.05433" actuatorfrcrange="-10 10"/>
+      <joint name="joint1" pos="0 0 0" axis="0 0 1" range="-2.61799 3.14159" actuatorfrcrange="-10 10"/>
       <geom pos="0.0374968 0.0464 0.119501" quat="9.38184e-07 -0.707105 9.38187e-07 0.707108" type="mesh" rgba="0.72549 0.45098 0.317647 1" mesh="link1"/>
       <body name="link2" pos="0.02 0.0329 0.0455" quat="9.38184e-07 9.38187e-07 0.707108 0.707105">
         <inertial pos="0.129165 0.000134495 -0.0321253" quat="0.499976 0.500008 0.500105 0.499911" mass="1.63122" diaginertia="0.0162876 0.0162103 0.000888393"/>
-        <joint name="joint2" pos="0 0 0" axis="0 0 1" range="0 3.14159" actuatorfrcrange="-10 10"/>
+        <joint name="joint2" pos="0 0 0" axis="0 0 1" range="0 3.66519" actuatorfrcrange="-10 10"/>
         <geom pos="-0.0174977 -0.0740001 -0.07925" quat="0.499998 0.5 0.500002 0.5" type="mesh" rgba="0 0.4 0.6 1" mesh="link2"/>
         <body name="link3" pos="0.264 4.08431e-07 -0.06375" quat="9.38184e-07 -0.707105 -0.707108 9.38187e-07">
           <inertial pos="0.0556042 -0.135083 -0.0340514" quat="0.704407 0.697077 0.121918 -0.0550519" mass="0.982553" diaginertia="0.00765198 0.0076296 0.000876442"/>
-          <joint name="joint3" pos="0 0 0" axis="0 0 1" range="0 3.66519" actuatorfrcrange="-10 10"/>
+          <joint name="joint3" pos="0 0 0" axis="0 0 1" range="0 3.14159" actuatorfrcrange="-10 10"/>
           <geom pos="0.0740003 -0.281499 -0.0813" quat="9.38184e-07 9.38187e-07 0.707108 0.707105" type="mesh" rgba="0.552941 0.580392 0.203922 1" mesh="link3"/>
           <body name="link4" pos="0.0600003 -0.244999 -0.00205" quat="1.32679e-06 0 0 -1">
             <inertial pos="-0.0543529 0.057068 -0.0332231" quat="0.636075 0.627088 0.370444 0.254833" mass="0.46678" diaginertia="0.000817855 0.000791274 0.000295776"/>
-            <joint name="joint4" pos="0 0 0" axis="0 0 1" range="-1.5708 1.5708" actuatorfrcrange="-10 10"/>
+            <joint name="joint4" pos="0 0 0" axis="0 0 1" range="-1.69297 1.5708" actuatorfrcrange="-10 10"/>
             <geom pos="-0.0138003 0.0364989 -0.0787882" quat="0.707105 0.707108 0 0" type="mesh" rgba="0.545098 0.52549 0.419608 1" mesh="link4"/>
             <body name="link5" pos="-0.0403003 0.0703851 -0.0323887" quat="9.38184e-07 -0.707105 -9.38187e-07 -0.707108">
               <inertial pos="-3.55003e-05 -0.00717397 0.0375847" quat="0.911516 0.411243 -0.00302177 -0.00303654" mass="0.403307" diaginertia="0.000219794 0.000195686 0.000169647"/>


### PR DESCRIPTION
## Summary

Bench testing revealed the joint working ranges in the YAM model files didn't match the real hardware, and the `.xml` / `.urdf` files were also inconsistent with each other across variants. This unifies **YAM Standard / Pro / Ultra** to the measured limits.

## Measured limits (new source of truth)

| Joint | Range | Change |
|-------|-------|--------|
| joint1 | -150° to **180°** | upper 175° → 180° |
| joint2 | 0° to **210°** | was 180°/209° (inconsistent across variants) |
| joint3 | 0° to **180°** | was 210° |
| joint4 | **-97°** to 90° | lower -90° → -97° |
| joint5 | -90° to 90° | unchanged |
| joint6 | -120° to 120° | unchanged |

## Files changed (6)

Both the MuJoCo `.xml` (authoritative — SDK enforces limits from here) and `.urdf` (external viz) for each of `yam`, `yam_pro`, `yam_ultra`.

## Bonus: fixed two clearly-broken URDF ranges

While correcting magnitudes, two obviously-wrong URDF limits were normalized to match:
- `yam_pro.urdf` joint3: `[-360°, 210°]` (570° span!) → `[0°, 180°]`
- `yam_ultra.urdf` joint2: `[-180°, 0°]` (reversed vs its own XML) → `[0°, 210°]`

## Scope note

**BIG YAM is intentionally NOT changed** — it has different mechanics (DM6248 shoulders, reversed joint directions) and needs its own bench measurement before its limits are touched.

## Verification

```
✓ yam.xml       loaded OK — j1[-150,180] j2[0,210] j3[0,180] j4[-97,90] j5[-90,90] j6[-120,120]
✓ yam_pro.xml   loaded OK — j1[-150,180] j2[0,210] j3[0,180] j4[-97,90] j5[-90,90] j6[-120,120]
✓ yam_ultra.xml loaded OK — j1[-150,180] j2[0,210] j3[0,180] j4[-97,90] j5[-90,90] j6[-120,120]
```

All three models load in MuJoCo and report the expected compiled joint ranges.

## Test plan
- [x] MuJoCo loads all three models without error
- [x] Compiled `jnt_range` matches measured values
- [ ] Reviewer with hardware: sanity-check joint2 210° and joint4 -97° against a physical arm

🤖 Generated with [Claude Code](https://claude.com/claude-code)