### PR TITLE
Join the control-loop thread before closing the CAN interface

### DIFF
--- a/i2rt/motor_drivers/dm_driver.py
+++ b/i2rt/motor_drivers/dm_driver.py
@@ -529,6 +529,7 @@ class DMChainCanInterface(MotorChain):
             return
         logging.info("starting separate thread for control loop")
         thread = threading.Thread(target=self._set_torques_and_update_state)
+        self._control_thread = thread
         thread.start()
         self.start_thread_flag = True
         time.sleep(0.1)
@@ -747,7 +748,15 @@ class DMChainCanInterface(MotorChain):
             return self.same_bus_device_states
 
     def close(self) -> None:
+        # Stop the control loop and wait for it to finish its current iteration
+        # BEFORE closing the CAN interface: closing the bus under a mid-flight
+        # _set_commands makes the thread crash on the dead socket (ValueError:
+        # "file descriptor cannot be a negative integer") and dump a traceback
+        # on every shutdown.
         self.running = False
+        thread = getattr(self, "_control_thread", None)
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=2.0)
         self.motor_interface.close()
 
 


### PR DESCRIPTION
## Problem

`DMChainCanInterface.close()` sets `running = False` and immediately closes the CAN interface. The control thread (`_set_torques_and_update_state`) is usually mid-iteration at that point — it checked `running` at the top of the loop — so its in-flight `_set_commands` hits the already-closed socket and crashes with:

```
ValueError: file descriptor cannot be a negative integer (-1)
```

plus a spurious `ERROR ... motor failed with info [...]` log. This happens on **every clean shutdown** of a YAM (observed on a bimanual rig: two arms → two tracebacks after every run), well after torques were already zeroed — cosmetic, but it makes healthy shutdowns look like crashes.

## Fix

Keep a handle to the control thread and `join()` it (2 s timeout) after clearing `running`, *before* closing the motor interface. Shutdowns are now silent past "Robot closed with all torques set to zero."

Tested on real hardware (2× YAM + LINEAR_4310 over socketcan): dozens of connect/run/close cycles since, zero shutdown tracebacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)