### PR TITLE
chore(deps): unpin ruckig, require >=0.19.4 which ships wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyyaml>=6.0.0",
     "qpsolvers[quadprog]==4.7.1",
     "rerun-sdk>=0.32.2",
-    "ruckig==0.15.3",
+    "ruckig>=0.19.4",
     "threadpoolctl==3.6.0",
     "tyro>=1.0.0",
     "viser>=0.2.0",
@@ -42,12 +42,6 @@ dev = [
     "pytest-xdist>=3.8.0",
     "ruff>=0.15.6",
 ]
-
-[tool.uv]
-# ruckig 0.15.3 publishes only an sdist, so it is compiled from source on a fresh
-# install (e.g. CI). Its build fails under scikit-build-core >= 0.10, which rejects the
-# package's deprecated `cmake.targets`. Pin the build backend below that so it builds.
-build-constraint-dependencies = ["scikit-build-core<0.10"]
 
 [tool.flit.module]
 name = "i2rt"

--- a/uv.lock
+++ b/uv.lock
@@ -9,9 +9,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[manifest]
-build-constraints = [{ name = "scikit-build-core", specifier = "<0.10" }]
-
 [[package]]
 name = "absl-py"
 version = "2.4.0"
@@ -314,10 +311,10 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "absl-py", marker = "python_full_version >= '3.14'" },
-    { name = "attrs", marker = "python_full_version >= '3.14'" },
-    { name = "numpy", marker = "python_full_version >= '3.14'" },
-    { name = "wrapt", marker = "python_full_version >= '3.14'" },
+    { name = "absl-py" },
+    { name = "attrs" },
+    { name = "numpy" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/83/ce29720ccf934c6cfa9b9c95ebbe96558386e66886626066632b5e44afed/dm_tree-0.1.9.tar.gz", hash = "sha256:a4c7db3d3935a5a2d5e4b383fc26c6b0cd6f78c6d4605d3e7b518800ecd5342b", size = 35623, upload-time = "2025-01-30T20:45:37.13Z" }
 wheels = [
@@ -353,10 +350,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "absl-py", marker = "python_full_version < '3.14'" },
-    { name = "attrs", marker = "python_full_version < '3.14'" },
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "wrapt", marker = "python_full_version < '3.14'" },
+    { name = "absl-py" },
+    { name = "attrs" },
+    { name = "numpy" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/66/a3ec619d22b6baffa5ab853e8dc6ec9d0c837127948af59bb15b988d7312/dm_tree-0.1.10.tar.gz", hash = "sha256:22f37b599e01cc3402a17f79c257a802aebd8d326de05b54657650845956208a", size = 35748, upload-time = "2026-03-31T17:35:39.03Z" }
 wheels = [
@@ -411,10 +408,10 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec", marker = "python_full_version < '3.11'" },
-    { name = "importlib-resources", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "fsspec" },
+    { name = "importlib-resources" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
 ]
 
 [[package]]
@@ -434,9 +431,9 @@ wheels = [
 
 [package.optional-dependencies]
 epath = [
-    { name = "fsspec", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
-    { name = "zipp", marker = "python_full_version >= '3.11'" },
+    { name = "fsspec" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
 ]
 
 [[package]]
@@ -444,7 +441,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -573,7 +570,7 @@ requires-dist = [
     { name = "qpsolvers", extras = ["quadprog"], specifier = "==4.7.1" },
     { name = "rerun-sdk", specifier = ">=0.32.2" },
     { name = "rpi-lgpio", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'armv6l' and sys_platform == 'linux') or (platform_machine == 'armv7l' and sys_platform == 'linux')", specifier = ">=0.6" },
-    { name = "ruckig", specifier = "==0.15.3" },
+    { name = "ruckig", specifier = ">=0.19.4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.6" },
     { name = "threadpoolctl", specifier = "==3.6.0" },
     { name = "tyro", specifier = ">=1.0.0" },
@@ -1627,9 +1624,41 @@ wheels = [
 
 [[package]]
 name = "ruckig"
-version = "0.15.3"
+version = "0.19.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/b7/d3d7c7f507ce8b6a7558418468e796d462dd2053ff3c555727c3f384941e/ruckig-0.15.3.tar.gz", hash = "sha256:48f68535080a594e45275201896c3a71123ac4a64c668eb3cf10b8bc42f34183", size = 870129, upload-time = "2025-05-16T14:04:55.521Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/2a/d1c1639bf76699ab1c3c1281101372f2b749d0ad8aee4c19200947b92785/ruckig-0.19.4.tar.gz", hash = "sha256:71d003bf0ff9aa0031d4520b0290a5ffa6458149f5afce8be3ed6d6fba49ea64", size = 886607, upload-time = "2026-07-15T06:59:43.034Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/7d/99ab1fd780813e6955b95e20fb251681b9515edfabb94306391d23de6a79/ruckig-0.19.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:43d3d004d3cbec7913dbb48d78349ba11d0c25437257f1aee0fa4a6ddfc33e80", size = 689080, upload-time = "2026-07-15T06:58:46.881Z" },
+    { url = "https://files.pythonhosted.org/packages/26/24/27afdb847db06257f5d57ceefe4d8de071eab5cbc7d5b5681bbfa6726866/ruckig-0.19.4-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb71e23d9fa7cdd3a5fab4fbc56819317276bc457381d8f6a21a7493a49465c", size = 1062830, upload-time = "2026-07-15T06:58:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/61/89/913a6a6c032ce9d5c8379f10991ab08847c3ed5e08dcecc6e7073e533244/ruckig-0.19.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a81a652d2ff1a1d7b74eb2b5e3aca1ae32f3df010a6ff3a5b961430f7b0410c5", size = 1561678, upload-time = "2026-07-15T06:58:50.22Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/97/a6e67c2e47a44518f10523d9f60fd4a738681b9f4c4b5c8c3108ab07b18a/ruckig-0.19.4-cp310-cp310-win32.whl", hash = "sha256:d5d34d0c33155af30291c032874605e2bcd164f2d10451bda4dd9a9c4e80b301", size = 1306546, upload-time = "2026-07-15T06:58:51.904Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c8/aafa2e06694c65bf779410a248ac44fd36ca3c4aabe6eced54cef47bd20c/ruckig-0.19.4-cp310-cp310-win_amd64.whl", hash = "sha256:4d70b25314d26f8740b7c350f0707ce4d322a108bc559c8b30091d207d4f4812", size = 1535012, upload-time = "2026-07-15T06:58:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/00/815fe81a7df845522e72d8e2c7f3f8178f737735bf92473a9da235e0e3ed/ruckig-0.19.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ac6133b08be5717d58fcb997d4ff3f0fa7e5427b2ae152c43e6a896a7694c0b0", size = 689081, upload-time = "2026-07-15T06:58:55.022Z" },
+    { url = "https://files.pythonhosted.org/packages/52/60/a8b7ebc2ee187a05d878a6c48b63a9a1bce5b9c1393ced89eeb959d9492c/ruckig-0.19.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ce3d7f701ba26eed841561ba2ed1a1804087afc1e996e83b5cd85bf6632e6c4", size = 1062888, upload-time = "2026-07-15T06:58:56.751Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ef/4684a822e0ab0ac592615266f62fcf2f208b271d6a2735326db580936f42/ruckig-0.19.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cdf8c0a1643a840a2aa4245edf38b35eac19985550fda8771862f9f1c4b12e77", size = 1561172, upload-time = "2026-07-15T06:58:58.296Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/74/26b471a0f3b3240f752e49a144b7d6a2b3e50d9a689e176598b3f8d89699/ruckig-0.19.4-cp311-cp311-win32.whl", hash = "sha256:d90f6c838291212acc9483f8115660c9a93595d4d4f6b3acd79f69e9da865874", size = 1306705, upload-time = "2026-07-15T06:59:00.453Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ae/fbec06c9631d271ffa29a75c11312995c42e6d17f77480b75ca1aaec07db/ruckig-0.19.4-cp311-cp311-win_amd64.whl", hash = "sha256:e90a7dafdffc03cac4d69df26d8b5ef2f0999e78fba41c59a31e18de7b6e2377", size = 1534816, upload-time = "2026-07-15T06:59:02.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cd/792797f51ec3b83fc6ee93b0b6eb057f3e1e3573138a4bc67914203bfd59/ruckig-0.19.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a353458a177992771edfef9f93baa3701642fd0f852059329e2addbf8686a8cd", size = 688146, upload-time = "2026-07-15T06:59:03.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/fae4e7af16e6156e0bdd8c3195cf29b4eaf6364cce5c06783703629b03ce/ruckig-0.19.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:347ad72d2003886c55a4c772ae686e82d808c2d9afb99318c287d3c0e24bf12e", size = 1061774, upload-time = "2026-07-15T06:59:05.356Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9e/67cb1b29c703bd034dc364d884f151913afbdc912eafb8885a7dedfdda4e/ruckig-0.19.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4b36110e4fb18c54db6308c9b3e9ed7a16559d90e640a4fdea4e25d37acbc0f2", size = 1560237, upload-time = "2026-07-15T06:59:06.861Z" },
+    { url = "https://files.pythonhosted.org/packages/73/d7/0d6a829e2d70accc6943c00e8d5584a21ae20a98a34372ad9b85507a72c0/ruckig-0.19.4-cp312-cp312-win32.whl", hash = "sha256:28d96e84fb600d15bbfaa2ce5c73f7a33e42b396ff3e700293557a52f1d2bcb3", size = 1306157, upload-time = "2026-07-15T06:59:08.317Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/1eac56a589f84007fb6fd25761612738345262e60cf517d8cae30dcc5146/ruckig-0.19.4-cp312-cp312-win_amd64.whl", hash = "sha256:9ca62445749dbcdb1533eb44ef8d434bdd43c33f7e274c9117698221c9c4d620", size = 1534285, upload-time = "2026-07-15T06:59:09.861Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/29/7c705a110ac2c25bfd4c6eeb27ab6b58f34afe25b36166587127216609e9/ruckig-0.19.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c9b9e98a1864d59dc67bb3a324a74a3eb92542e8fadb09575522097f51a54248", size = 688153, upload-time = "2026-07-15T06:59:11.498Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/c6/b0ac54f514570bd2626a472e9ec2f8c60353e6156a6c85dbe17929d62ab1/ruckig-0.19.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2566a9cb27d3379d113696e5d885c6a3b3a6e10dce2503598aa1b317d8b5cfb6", size = 1061699, upload-time = "2026-07-15T06:59:13.054Z" },
+    { url = "https://files.pythonhosted.org/packages/82/bd/1eb52b4412f91f1043c8de0c56f23f2c2bdd4c05ffec4baaa75cbcfdcd04/ruckig-0.19.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da0887ac090c327a97a366f6b0b5ec8bfdb28836c20a1afcc4ee5c1bbbd31149", size = 1560189, upload-time = "2026-07-15T06:59:14.82Z" },
+    { url = "https://files.pythonhosted.org/packages/16/42/610cea86a003a8a3475a683c91268f5c524200f5c585fbda6ce3c49572ba/ruckig-0.19.4-cp313-cp313-win32.whl", hash = "sha256:4adc97fdaca33021f311d71925411e79d6fb41e6123b01dd797465111f9a8488", size = 1306132, upload-time = "2026-07-15T06:59:16.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/bb/48004d2bb468fee790644e9ed0fefe18929d97dfbadd369553121b8a894b/ruckig-0.19.4-cp313-cp313-win_amd64.whl", hash = "sha256:b5a3cbe5bced4b0993e93737000c49c574786cebca314d1bed725cd44114645c", size = 1534216, upload-time = "2026-07-15T06:59:17.783Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f1/4046cfebcde683672c0c33f1ee0a94474c87db83849eaf8d4ec7ce3454ac/ruckig-0.19.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8406833bbf6fd11f6e6c46ae9290c0a68d6f8abb77590619459e957b66b4c3bc", size = 687981, upload-time = "2026-07-15T06:59:19.461Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/78/3dc19956097ac690f885e4d8e979f3905977ff546f6bdb7386d73e3f31f8/ruckig-0.19.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a32ad56149f34783728f08da67b088ffacc2074f247946da7d83f265af35e82", size = 1061812, upload-time = "2026-07-15T06:59:21.011Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5d/f84d61401b7da196c8bd995fa833ee8cecf9d1e1e8f4d5ff547428ec2b8f/ruckig-0.19.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5640da60eaf7746942eac6c11a7f0d0ca86a66e3270e7b0fffdedcc1c125a18c", size = 1559934, upload-time = "2026-07-15T06:59:22.762Z" },
+    { url = "https://files.pythonhosted.org/packages/87/8e/6a49a0b43812bc19684e2bd462e64a22b81b4647bcff759a8577b2f08736/ruckig-0.19.4-cp314-cp314-win32.whl", hash = "sha256:45a0d6eda72e8515a7fea4d77a8794671077b9f350c2adcf65352072472d72c3", size = 1320911, upload-time = "2026-07-15T06:59:24.281Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7b/83c7d6d08bdac0cb43eafce2d8ce01829f9a3f15ba5937c61e028ea64ebb/ruckig-0.19.4-cp314-cp314-win_amd64.whl", hash = "sha256:c57f6405bd00511fcce21aba34ffda8052f4478cd7f0a780607774cdc83bcaf5", size = 1552893, upload-time = "2026-07-15T06:59:25.864Z" },
+    { url = "https://files.pythonhosted.org/packages/56/69/63d6f0080ddc7fa0a4bcd556785ecb9ab7148dd5f89e7eadeb48c27a2e56/ruckig-0.19.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b2a95c93f0786b78ca5fbd753ff23525f33df761a11ba3bc8ffb114c51545f69", size = 691120, upload-time = "2026-07-15T06:59:27.353Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/5db0cae7f93a821a99c9814a1c2073a58852ad2c42a09d9b7f6597c01169/ruckig-0.19.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:418bd43087271579b4799f5c5d09a32ee9cda73b890bd6d163a130d75b6ba4f3", size = 1065497, upload-time = "2026-07-15T06:59:28.873Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e1/dd55caa81e62179d39ecc8409e053fc75ad9a330bcf816ee90176f798feb/ruckig-0.19.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2a54d6e271fbcba67db9a3291e823ee5f6bbc15e33b328376282f1ff5256b000", size = 1563991, upload-time = "2026-07-15T06:59:30.684Z" },
+    { url = "https://files.pythonhosted.org/packages/36/88/13949791de7844b6556416e13983eb68fec02314b7bb29b1c2cdfa531d44/ruckig-0.19.4-cp314-cp314t-win32.whl", hash = "sha256:31e94f695b74f1c01a533256354428365627a0ce5d78d8f8588eaf5a9f067e61", size = 1322699, upload-time = "2026-07-15T06:59:32.527Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/8a/45afac0f3c376adef1ac356ae6d663bad96bb0917c8a353c5c416a4d6864/ruckig-0.19.4-cp314-cp314t-win_amd64.whl", hash = "sha256:7a6566d207f34c1e493be8092669a2c3f4194c80dda71eea86ae45c7fb804f6c", size = 1555930, upload-time = "2026-07-15T06:59:34.095Z" },
+]
 
 [[package]]
 name = "ruff"
@@ -1664,7 +1693,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -1726,7 +1755,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.11'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [


### PR DESCRIPTION
Fixes #76.

## Problem

`ruckig==0.15.3` publishes only an sdist, and every published ruckig sdist through 0.17.3 fails to build under scikit-build-core >= 0.10 (the deprecated `cmake.targets` key became a hard error in scikit-build-core 1.0, released 2026-07-06). The `[tool.uv] build-constraint-dependencies` workaround in this repo only protects builds run inside the repo itself: uv ignores a dependency's `[tool.uv]` section, so anyone installing i2rt as a dependency (`uv pip install "i2rt @ git+..."`, pip, CI) hits the build failure on a cold cache.

## Fix

ruckig 0.19.4 (released today, includes the pantor/ruckig#261 fix per pantor/ruckig#263) ships prebuilt wheels for CPython 3.9-3.14 on manylinux/musllinux x86_64, macOS arm64, and Windows, so no source build happens on those platforms. On platforms without wheels (e.g. Linux aarch64 / Raspberry Pi), the 0.19.4 sdist builds cleanly under scikit-build-core 1.0, so the build-constraint block is removed as no longer needed. Lockfile updated with `uv lock --upgrade-package ruckig` (the extra marker simplifications are from 0.19.4 supporting Python 3.14, which removes a resolution fork).

## Compatibility

The only ruckig consumer in the codebase is `i2rt/flow_base/flow_base_controller.py`. I exercised its full ruckig API surface (`Ruckig`, `InputParameter`, `OutputParameter`, `ControlInterface`, `Result`, `update()`, `pass_to_input()`) against 0.19.4: identical behavior, `update()` returns `Result.Working`, and the module imports cleanly with 0.19.4 installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)